### PR TITLE
feat: add confusion matrix for tool calls match rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2026-03-18
+
+### Changed
+- **ToolCalls-Match-Rate redefined**: Changed from simple "proportion of triggered tool calls" to a match rate based on expected labels
+  - New formula: `tool_calls_accuracy = (tool_calls_finish_tool_calls + stop_finish_stop) / success_count`
+  - i.e., proportion of cases where actual result matches expected result
+
+### Added
+- Added `expected_tool_call` label field to test set `sample.jsonl`, indicating whether each case is expected to trigger a tool call
+- Added confusion matrix statistics:
+  - `tool_calls_finish_tool_calls`: expected tool_call, actual tool_call (True Positive)
+  - `tool_calls_finish_stop`: expected tool_call, actual stop (False Negative)
+  - `stop_finish_tool_calls`: expected stop, actual tool_call (False Positive)
+  - `stop_finish_stop`: expected stop, actual stop (True Negative)
+- Added `expected_tool_call` field to results, recording the expected label from the original request
+
+### Fixed
+- Backward compatible with historical data without `expected_tool_call` label (incremental mode)
+
+## [1.0.0] - 2026-01-18
+
+### Changed
+- Stable release
+
 ## [0.1.0] - 2025-11-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2026-03-19
+
+### Added
+- **Batch verification script** (`run_batch_sequential.sh`): New script for running pass@10 verification tests
+  - Supports 10 iterations by default for statistical significance
+  - Auto-generates metrics reports and baseline comparisons
+  - Parameters: `--module`, `--url`, `--model`, `--api-key`, `--max-workers`, `--mm-model`, etc.
+- Added `expected_tool_call_total_count` to summary statistics in `validator/tool_calls.py`
+- Added batch testing documentation to README.md and README_CN.md
+- New script dependencies:
+  - `scripts/batch_verify.py`: Batch verification executor
+  - `scripts/calculate_batch_metrics.py`: Metrics aggregation and calculation
+  - `scripts/compare_with_baseline.py`: Baseline comparison tool
+  - `scripts/calculate_toolcall_similarity.py`: Tool call similarity calculator
+
+### Changed
+- **ToolCalls-Match-Rate denominator**: Now uses `expected_tool_call` label count from `sample.jsonl` as the denominator for more accurate match rate calculation
+- All Chinese comments and outputs converted to English for better internationalization
+- `calculate_batch_metrics.py` now reads `expected_tool_call` statistics directly from `sample.jsonl`
+
+### Fixed
+- Fixed path consistency issues in shell script calling Python scripts
+
 ## [1.1.0] - 2026-03-18
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -13,20 +13,17 @@ The primary metrics are:
 * **Query-Success-Rate:** Measures the probability that a provider can eventually return a valid response successfully when allowed up to `max_retry=10` attempts.
   - `query_success_rate = successful_query_count / total_query_count`
 
-* **Finish-ToolCalls-Rate:** Measures the proportion of triggered tool-calls that successfully reach a completed tool-call result, regardless of argument correctness.
-  - `finish_tool_calls_rate = finish_tool_calls_count / total_query_count`
+* **ToolCalls-Match-Rate:** Measures how well the model's "whether to trigger tool-calls" behavior matches the expected labels. Each test case is annotated with `expected_tool_call` (whether a tool call is expected), and this metric calculates the proportion of cases where the actual result matches the expected result.
+  - `tool_calls_match_rate = (tool_calls_finish_tool_calls + stop_finish_stop) / success_count`
+  - Confusion Matrix Statistics:
+    - `tool_calls_finish_tool_calls`: expected tool_call, actual tool_call (TP)
+    - `tool_calls_finish_stop`: expected tool_call, actual stop (FN)
+    - `stop_finish_tool_calls`: expected stop, actual tool_call (FP)
+    - `stop_finish_stop`: expected stop, actual stop (TN)
 
-* **ToolCalls-Trigger Similarity:** Measures the similarity of "whether to trigger tool-calls" between a provider and a official reference, using the F1 score (harmonic mean of precision and recall). This mirrors the methodology popularized in K2 Vendor Verifier and is used to detect deployment correctness at the decision level. See reference: [MoonshotAI/K2-Vendor-Verifier](https://github.com/MoonshotAI/K2-Vendor-Verifier).
+* **ToolCalls-Schema-Accuracy:** Measures the correctness rate of tool-call payloads (e.g., function name and arguments meeting the expected schema) conditional on tool-call being triggered.
+  - `schema_accuracy = tool_calls_successful_count / tool_calls_finish_tool_calls`
 
-  - Define `TP = count(provider triggers AND official reference triggers)`, `FP = count(provider triggers AND official reference does not)`, `FN = count(provider does not AND official reference triggers)`
-
-  - `Precision = TP / (TP + FP)`, `Recall = TP / (TP + FN)`
-
-  - `F1 = 2 · Precision · Recall / (Precision + Recall)`
-
-
-* **ToolCalls-Accuracy:** Measures the correctness rate of tool-call payloads (e.g., function name and arguments meeting the expected schema) conditional on tool-call being triggered.
-  - `accuracy = tool_calls_successful_count / tool_calls_finish_tool_calls`
 
 * **Response-Success-Rate Not Only Reasoning:** Detects a specific error pattern where the model outputs only Chain-of-Thought reasoning without providing valid content or the required tool calls. The presence of this pattern strongly indicates a deployment issue.
   - `Response-success-rate = response_not_only_reasoning_count / only_reasoning_checked_count`

--- a/README.md
+++ b/README.md
@@ -128,6 +128,43 @@ python verify.py sample.jsonl \
 - `--extra-body` (optional, JSON string): Extra fields to merge into each request's payload (e.g., decoding parameters).
 - `--incremental` (flag): Only rerun previously failed or new requests, merging with existing output; recomputes the summary.
 
+### Batch Testing (Recommended: pass@10)
+
+For comprehensive evaluation with statistical significance, we recommend using the batch verification script which runs multiple iterations and aggregates metrics:
+
+```bash
+bash run_batch_sequential.sh \
+  --module 'provider-name' \
+  --url 'https://api.example.com/v1/' \
+  --model 'model-name' \
+  --api-key 'your-api-key' \
+  --max-workers 10 \
+  --mm-model 'MiniMax-M2.5'
+```
+
+**Parameters:**
+
+- `--module`: Provider/module name (required)
+- `--url`: API endpoint URL (required)
+- `--model`: Model name (required)
+- `--api-key`: API key (required)
+- `--max-workers`: Concurrent request count (default: 10)
+- `--stream`: Enable streaming mode
+- `--debug`: Debug mode, only run first 10 cases
+- `--extra-body`: Extra request body parameters (JSON format)
+- `--mm-model`: MiniMax baseline model name for comparison (default: MiniMax-M2.5)
+
+The script will:
+1. Execute 10 verification loops (pass@10)
+2. Calculate aggregated metrics across all loops
+3. Compare results with the baseline model
+4. Generate detailed metrics reports in `output-dir/batch_<timestamp>/`
+
+**Output:**
+- `metrics_report.json`: Aggregated metrics from all loops
+- `comparison_report.json`: Comparison with baseline model
+- Individual loop results in `loop_01/`, `loop_02/`, etc.
+
 ## Roadmap
 
 - [ ] Expand and refine the evaluation set.

--- a/README_CN.md
+++ b/README_CN.md
@@ -13,20 +13,17 @@
 * **请求成功率（Query-Success-Rate）：** 衡量在允许最多 `max_retry=10` 次尝试的情况下，供应商最终成功返回有效响应的概率。
   - `query_success_rate = successful_query_count / total_query_count`
 
-* **工具调用率（Finish-ToolCalls-Rate）：** 模型触发工具调用的比例（不考量参数正确性，仅考量是否触发）。
-  - `finish_tool_calls_rate = finish_tool_calls_count / total_query_count`
+* **工具调用匹配率（ToolCalls-Match-Rate）：** 衡量模型在"是否触发工具调用"这一行为上与预期标签的匹配程度。每个测试用例都标注了 `expected_tool_call`（是否预期触发工具调用），该指标计算预期与实际结果相符的比例。
+  - `tool_calls_match_rate = (tool_calls_finish_tool_calls + stop_finish_stop) / success_count`
+  - 四项限统计（混淆矩阵）：
+    - `tool_calls_finish_tool_calls`: 预期 tool_call，实际 tool_call (TP)
+    - `tool_calls_finish_stop`: 预期 tool_call，实际 stop (FN)
+    - `stop_finish_tool_calls`: 预期 stop，实际 tool_call (FP)
+    - `stop_finish_stop`: 预期 stop，实际 stop (TN)
 
-* **工具调用触发相似度（ToolCalls-Trigger Similarity）：**  使用 F1 Score 衡量供应商模型与官方参考模型在“是否触发工具”这一行为上的一致性。引用了 K2-Vendor-Verifier 中使用的方法，用于检测部署正确性。参考：[MoonshotAI/K2-Vendor-Verifier](https://github.com/MoonshotAI/K2-Vendor-Verifier)。
+* **工具调用参数准确率（ToolCalls-Schema-Accuracy）：** 在触发工具调用的前提下，生成的函数名和参数符合预期模式的比例。
+  - `schema_accuracy = tool_calls_successful_count / tool_calls_finish_tool_calls`
 
-  - 定义 `TP = count(供应商触发 AND 官方触发)`, `FP = count(供应商触发 AND 官方未触发)`, `FN = count(供应商未触发 AND 官方触发)`
-
-  - `Precision = TP / (TP + FP)`, `Recall = TP / (TP + FN)`
-
-  - `F1 = 2 · Precision · Recall / (Precision + Recall)`
-
-
-* **工具调用准确率（ToolCalls-Accuracy）：** 在触发工具调用的前提下，生成的函数名和参数符合预期模式的比例。
-  - `accuracy = tool_calls_successful_count / tool_calls_finish_tool_calls`
 
 * **响应有效率（Response-Success-Rate Not Only Reasoning）：** 检测模型是否陷入“仅输出推理过程（Chain-of-Thought）但无有效内容或工具调用”的错误模式。此类模式通常意味着部署存在问题。
   - `Response-success-rate = response_not_only_reasoning_count / only_reasoning_checked_count`

--- a/README_CN.md
+++ b/README_CN.md
@@ -128,6 +128,43 @@ python verify.py sample.jsonl \
 - `--extra-body` (可选，JSON 字符串): 要合并到每个请求中的额外字段（例如解码参数）。
 - `--incremental` (标志): 仅重新运行之前失败或新的请求，与现有输出合并，重新统计结果。
 
+### 批量测试（推荐：pass@10）
+
+为了获得具有统计显著性的全面评估结果，我们推荐使用批量验证脚本，该脚本会执行多次迭代并聚合指标：
+
+```bash
+bash run_batch_sequential.sh \
+  --module 'provider-name' \
+  --url 'https://api.example.com/v1/' \
+  --model 'model-name' \
+  --api-key 'your-api-key' \
+  --max-workers 10 \
+  --mm-model 'MiniMax-M2.5'
+```
+
+**参数说明：**
+
+- `--module`: Provider/模块名称（必需）
+- `--url`: API 端点 URL（必需）
+- `--model`: 模型名称（必需）
+- `--api-key`: API 密钥（必需）
+- `--max-workers`: 并发请求数（默认：10）
+- `--stream`: 启用流式模式
+- `--debug`: 调试模式，仅运行前 10 个用例
+- `--extra-body`: 额外的请求体参数（JSON 格式）
+- `--mm-model`: 用于对比的 MiniMax 基准模型名称（默认：MiniMax-M2.5）
+
+脚本将执行以下操作：
+1. 执行 10 次验证循环（pass@10）
+2. 计算所有循环的聚合指标
+3. 与基准模型进行对比
+4. 在 `output-dir/batch_<timestamp>/` 中生成详细的指标报告
+
+**输出文件：**
+- `metrics_report.json`: 所有循环的聚合指标
+- `comparison_report.json`: 与基准模型的对比结果
+- 各循环的单独结果位于 `loop_01/`、`loop_02/` 等目录
+
 ## 后续计划
 
 - [ ] 扩展和完善评估集。

--- a/run_batch_sequential.sh
+++ b/run_batch_sequential.sh
@@ -1,0 +1,411 @@
+#!/bin/bash
+
+#=============================================================================
+# MiniMax Provider Verifier - Batch Verification Script
+# 
+# Usage: 
+#   bash run_batch_sequential.sh \
+#     --module 'test' \
+#     --url 'https://api.example.com/v1/chat/completions' \
+#     --model 'model-name' \
+#     --api-key 'sk-xxx' \
+#     --max-workers 10
+#
+# Parameters:
+#   --module              Module name (required)
+#   --url                 API URL (required)
+#   --model               Model name (required)
+#   --api-key             API Key (required)
+#   --max-workers         Concurrent requests (default: 10)
+#   --stream              Use streaming mode (default: false)
+#   --debug               Debug mode, only run first 10 cases
+#   --extra-body          Extra request body parameters (JSON format)
+#   --mm-model            MiniMax baseline model name (default: MiniMax-M2.5)
+#=============================================================================
+
+echo "========================================="
+echo "MiniMax Provider Verifier - Batch Verification"
+echo "========================================="
+
+# Get script directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$SCRIPT_DIR"
+cd "$PROJECT_ROOT"
+
+echo "📂 Project root: $PROJECT_ROOT"
+
+# Default parameter values
+MODULE=""
+MAX_WORKERS="10"
+STREAM_MODE=""
+DEBUG_MODE=""
+EXTRA_BODY=""
+DIRECT_URL=""
+DIRECT_MODEL=""
+DIRECT_API_KEY=""
+MM_MODEL="MiniMax-M2.5"
+LOOP_COUNT="10"
+
+# Parse command line arguments
+echo "📋 Parsing command line arguments..."
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --module)
+            MODULE="$2"
+            shift 2
+            ;;
+        --max-workers)
+            MAX_WORKERS="$2"
+            shift 2
+            ;;
+        --stream)
+            STREAM_MODE="true"
+            shift
+            ;;
+        --debug)
+            DEBUG_MODE="true"
+            shift
+            ;;
+        --extra-body)
+            EXTRA_BODY="$2"
+            shift 2
+            ;;
+        --url)
+            DIRECT_URL="$2"
+            shift 2
+            ;;
+        --model)
+            DIRECT_MODEL="$2"
+            shift 2
+            ;;
+        --api-key)
+            DIRECT_API_KEY="$2"
+            shift 2
+            ;;
+        --mm-model)
+            MM_MODEL="$2"
+            shift 2
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+
+# Check required parameters
+MISSING_PARAMS=""
+if [ -z "$MODULE" ]; then
+    MISSING_PARAMS="$MISSING_PARAMS --module"
+fi
+if [ -z "$DIRECT_URL" ]; then
+    MISSING_PARAMS="$MISSING_PARAMS --url"
+fi
+if [ -z "$DIRECT_MODEL" ]; then
+    MISSING_PARAMS="$MISSING_PARAMS --model"
+fi
+if [ -z "$DIRECT_API_KEY" ]; then
+    MISSING_PARAMS="$MISSING_PARAMS --api-key"
+fi
+
+if [ -n "$MISSING_PARAMS" ]; then
+    echo "❌ Error: Missing required parameters:$MISSING_PARAMS"
+    echo ""
+    echo "Usage:"
+    echo "  bash run_batch_sequential.sh \\"
+    echo "    --module 'test' \\"
+    echo "    --url 'https://api.example.com/v1/chat/completions' \\"
+    echo "    --model 'model-name' \\"
+    echo "    --api-key 'sk-xxx' \\"
+    echo "    --max-workers 10"
+    echo ""
+    echo "Parameters:"
+    echo "  --module       Module name (required)"
+    echo "  --url          API URL (required)"
+    echo "  --model        Model name (required)"
+    echo "  --api-key      API Key (required)"
+    echo "  --max-workers  Concurrent requests (default: 10)"
+    echo "  --stream       Use streaming mode"
+    echo "  --debug        Debug mode"
+    exit 1
+fi
+
+# Print parameters
+echo ""
+echo "✅ Parameters parsed:"
+echo "  --module: $MODULE"
+echo "  --url: $DIRECT_URL"
+echo "  --model: $DIRECT_MODEL"
+echo "  --api-key: ******"
+echo "  --max-workers: $MAX_WORKERS"
+echo "  --loop: $LOOP_COUNT"
+echo "  --stream: ${STREAM_MODE:-false}"
+echo "  --debug: ${DEBUG_MODE:-false}"
+echo "  --mm-model: $MM_MODEL"
+
+# Set output directory
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+OUTPUT_BASE_DIR="$PROJECT_ROOT/output-dir/batch_${TIMESTAMP}"
+echo ""
+echo "📁 Loop mode: Will run $LOOP_COUNT times"
+echo "📁 Output base directory: $OUTPUT_BASE_DIR"
+mkdir -p "$OUTPUT_BASE_DIR"
+
+# Check Python environment
+echo ""
+echo "========================================="
+echo "🐍 Python Environment Check"
+echo "========================================="
+
+if command -v python3 &> /dev/null; then
+    PYTHON_CMD="python3"
+else
+    echo "❌ Error: Python3 not found"
+    exit 1
+fi
+
+echo "Using Python: $PYTHON_CMD"
+echo "Python version: $($PYTHON_CMD --version)"
+
+# Check if using uv
+if command -v uv &> /dev/null; then
+    echo "✅ Detected uv, will use uv run"
+    USE_UV=1
+else
+    echo "ℹ️  uv not detected, will use python directly"
+    USE_UV=0
+fi
+
+# Set PYTHONPATH
+export PYTHONPATH="$PROJECT_ROOT:${PYTHONPATH}"
+echo "✅ PYTHONPATH set"
+
+# Create necessary directories
+mkdir -p "$PROJECT_ROOT/logs"
+
+echo ""
+echo "========================================="
+echo "🚀 Starting Batch Verification Tasks"
+echo "========================================="
+
+# Record all loop results
+declare -a ALL_LOOPS_RESULTS
+
+# Process URL: remove /chat/completions (OpenAI SDK will auto-append)
+PROCESSED_URL="$DIRECT_URL"
+if [[ "$DIRECT_URL" == */chat/completions ]]; then
+    PROCESSED_URL="${DIRECT_URL%/chat/completions}"
+    echo "⚠️  Detected URL contains /chat/completions, auto-removed"
+fi
+
+# Set MODEL_NAME environment variable
+export MODEL_NAME="$DIRECT_MODEL"
+
+# Outer loop: execute verification LOOP_COUNT times
+for LOOP_IDX in $(seq 1 $LOOP_COUNT); do
+    # Format loop number
+    if [ $LOOP_IDX -lt 10 ]; then
+        LOOP_NUM="0${LOOP_IDX}"
+    else
+        LOOP_NUM="${LOOP_IDX}"
+    fi
+    
+    echo ""
+    echo "========================================"
+    echo "🔄 Loop ${LOOP_IDX}/${LOOP_COUNT}"
+    echo "========================================"
+    
+    # Create loop output directory
+    LOOP_OUTPUT_DIR="$OUTPUT_BASE_DIR/loop_${LOOP_NUM}"
+    mkdir -p "$LOOP_OUTPUT_DIR"
+    echo "📂 Loop output directory: $LOOP_OUTPUT_DIR"
+    
+    # Create module output directory
+    MODULE_OUTPUT_DIR="$LOOP_OUTPUT_DIR/${MODULE}"
+    mkdir -p "$MODULE_OUTPUT_DIR"
+    
+    # Generate log file
+    LOG_FILE="$MODULE_OUTPUT_DIR/verifier.log"
+    
+    # Generate provider.json
+    TEMP_PROVIDER="$MODULE_OUTPUT_DIR/provider.json"
+    cat > "$TEMP_PROVIDER" << EOF
+[
+  {
+    "name": "$MODULE",
+    "model": "$DIRECT_MODEL",
+    "base_url": "$PROCESSED_URL",
+    "api_key": "$DIRECT_API_KEY"
+  }
+]
+EOF
+    
+    # Copy test data
+    TEMP_JSONL="$MODULE_OUTPUT_DIR/test_data.jsonl"
+    SAMPLE_JSONL="$PROJECT_ROOT/sample.jsonl"
+    if [ -f "$SAMPLE_JSONL" ]; then
+        cp "$SAMPLE_JSONL" "$TEMP_JSONL"
+    else
+        echo "[$(date '+%Y-%m-%d %H:%M:%S')] ⚠️  sample.jsonl not found"
+        ALL_LOOPS_RESULTS+=("LOOP_${LOOP_NUM}:FAILED")
+        continue
+    fi
+    
+    # Build verification command arguments
+    VERIFY_ARGS="$TEMP_JSONL --provider-file $TEMP_PROVIDER --output-dir $MODULE_OUTPUT_DIR --parallel-providers 1 --max-workers $MAX_WORKERS"
+    if [ "$STREAM_MODE" = "true" ]; then
+        VERIFY_ARGS="$VERIFY_ARGS --stream"
+    fi
+    if [ "$DEBUG_MODE" = "true" ]; then
+        VERIFY_ARGS="$VERIFY_ARGS --debug"
+    fi
+    
+    # Build base command
+    if [ $USE_UV -eq 1 ]; then
+        BASE_CMD="uv run $PYTHON_CMD"
+    else
+        BASE_CMD="$PYTHON_CMD"
+    fi
+    
+    # Execute verification
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] 🔍 Starting verification..."
+    if [ -n "$EXTRA_BODY" ]; then
+        $BASE_CMD "$SCRIPT_DIR/scripts/batch_verify.py" $VERIFY_ARGS --extra-body "$EXTRA_BODY" >> "$LOG_FILE" 2>&1
+    else
+        $BASE_CMD "$SCRIPT_DIR/scripts/batch_verify.py" $VERIFY_ARGS >> "$LOG_FILE" 2>&1
+    fi
+    
+    EXIT_CODE=$?
+    if [ $EXIT_CODE -eq 0 ]; then
+        echo "[$(date '+%Y-%m-%d %H:%M:%S')] ✅ Loop ${LOOP_IDX} completed successfully"
+        ALL_LOOPS_RESULTS+=("LOOP_${LOOP_NUM}:SUCCESS")
+    else
+        echo "[$(date '+%Y-%m-%d %H:%M:%S')] ❌ Loop ${LOOP_IDX} failed (exit code: ${EXIT_CODE})"
+        ALL_LOOPS_RESULTS+=("LOOP_${LOOP_NUM}:FAILED")
+    fi
+done
+
+# ========================================
+# Statistics
+# ========================================
+
+echo ""
+echo "=========================================="
+echo "📊 All Verification Tasks Completed"
+echo "=========================================="
+echo "Total loops: $LOOP_COUNT"
+echo ""
+
+SUCCESSFUL_LOOPS=0
+for result in "${ALL_LOOPS_RESULTS[@]}"; do
+    IFS=':' read -ra PARTS <<< "$result"
+    LOOP_NAME="${PARTS[0]}"
+    STATUS="${PARTS[1]}"
+    
+    if [ "$STATUS" == "SUCCESS" ]; then
+        SUCCESSFUL_LOOPS=$((SUCCESSFUL_LOOPS + 1))
+        echo "  ✅ $LOOP_NAME: Success"
+    else
+        echo "  ❌ $LOOP_NAME: Failed"
+    fi
+done
+
+echo ""
+echo "Successful loops: ${SUCCESSFUL_LOOPS}/${LOOP_COUNT}"
+
+if [ $SUCCESSFUL_LOOPS -eq 0 ]; then
+    echo ""
+    echo "⚠️  All tasks failed, cannot collect metrics"
+    exit 1
+fi
+
+# ========================================
+# Collect Metrics
+# ========================================
+
+echo ""
+echo "=========================================="
+echo "📈 Collecting Metrics"
+echo "=========================================="
+
+METRICS_REPORT="$OUTPUT_BASE_DIR/metrics_report.json"
+REPORT_PROVIDER_NAME="$MODULE"
+
+echo "📦 Using provider: $REPORT_PROVIDER_NAME"
+
+if [ $USE_UV -eq 1 ]; then
+    uv run $PYTHON_CMD "$SCRIPT_DIR/scripts/calculate_batch_metrics.py" \
+        --root-dir "$OUTPUT_BASE_DIR" \
+        --provider "$REPORT_PROVIDER_NAME" \
+        --detailed \
+        --output "$METRICS_REPORT"
+else
+    $PYTHON_CMD "$SCRIPT_DIR/scripts/calculate_batch_metrics.py" \
+        --root-dir "$OUTPUT_BASE_DIR" \
+        --provider "$REPORT_PROVIDER_NAME" \
+        --detailed \
+        --output "$METRICS_REPORT"
+fi
+
+if [ $? -eq 0 ]; then
+    echo "✅ Metrics collection completed"
+    echo "📊 Metrics report: $METRICS_REPORT"
+else
+    echo "⚠️  Metrics collection failed"
+fi
+
+# ========================================
+# Compare with Baseline
+# ========================================
+
+BASELINE_DIR="$PROJECT_ROOT/$MM_MODEL"
+COMPARISON_REPORT="$OUTPUT_BASE_DIR/comparison_report.json"
+
+if [ -d "$BASELINE_DIR" ]; then
+    echo ""
+    echo "=========================================="
+    echo "📊 Comparing with Baseline"
+    echo "=========================================="
+    echo "📂 Baseline directory: $BASELINE_DIR"
+    
+    if [ $USE_UV -eq 1 ]; then
+        uv run $PYTHON_CMD "$SCRIPT_DIR/scripts/compare_with_baseline.py" \
+            --result-dir "$OUTPUT_BASE_DIR" \
+            --baseline-dir "$BASELINE_DIR" \
+            --provider "$REPORT_PROVIDER_NAME" \
+            --output "$COMPARISON_REPORT"
+    else
+        $PYTHON_CMD "$SCRIPT_DIR/scripts/compare_with_baseline.py" \
+            --result-dir "$OUTPUT_BASE_DIR" \
+            --baseline-dir "$BASELINE_DIR" \
+            --provider "$REPORT_PROVIDER_NAME" \
+            --output "$COMPARISON_REPORT"
+    fi
+    
+    if [ $? -eq 0 ]; then
+        echo "✅ Baseline comparison completed"
+        METRICS_REPORT="$COMPARISON_REPORT"
+    fi
+else
+    echo ""
+    echo "ℹ️  Baseline directory $BASELINE_DIR not found, skipping baseline comparison"
+fi
+
+# ========================================
+# Complete
+# ========================================
+
+echo ""
+echo "=========================================="
+echo "🎉 All Tasks Completed!"
+echo "=========================================="
+echo "📂 Results saved at: $OUTPUT_BASE_DIR"
+echo ""
+echo "📊 Summary:"
+echo "  - Total loops: $LOOP_COUNT"
+echo "  - Successful loops: $SUCCESSFUL_LOOPS"
+echo "  - Failed loops: $((LOOP_COUNT - SUCCESSFUL_LOOPS))"
+echo "  - Metrics report: $METRICS_REPORT"
+echo ""
+echo "💡 View metrics:"
+echo "   cat $METRICS_REPORT | jq '.summary'"
+echo ""

--- a/scripts/batch_verify.py
+++ b/scripts/batch_verify.py
@@ -1,0 +1,314 @@
+import argparse
+import asyncio
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+
+import megfile
+from loguru import logger
+from verify import ValidatorRunner
+
+
+
+async def run_provider_verification(
+    provider_config: dict,
+    file_path: str,
+    concurrency: int,
+    timeout: int,
+    max_retries: int,
+    output_dir: str,
+    incremental: bool,
+    stream: bool = False,
+    debug: bool = False,
+    openrouter_provider: str = None,
+    api_format: str = "openai",
+    extra_body: dict = None,
+) -> dict:
+    """Run verification for a single provider"""
+    provider_name = provider_config["name"]
+    logger.info(f"Starting verification for provider: {provider_name}")
+    
+    # Create separate output files for each provider
+    output_file = os.path.join(output_dir, f"{provider_name}_results.jsonl")
+    summary_file = os.path.join(output_dir, f"{provider_name}_summary.json")
+    
+    try:
+        # 合并 extra_body：命令行参数优先级高于 provider_config
+        merged_extra_body = provider_config.get("extra_body", {})
+        if extra_body:
+            merged_extra_body.update(extra_body)
+        
+        if merged_extra_body:
+            logger.info(f"📦 Using extra_body for provider {provider_name}: {merged_extra_body}")
+        
+        runner = ValidatorRunner(
+            model=provider_config["model"],
+            base_url=provider_config["base_url"],
+            api_key=provider_config["api_key"],
+            concurrency=concurrency,
+            output_file=output_file,
+            summary_file=summary_file,
+            timeout=timeout,
+            max_retries=max_retries,
+            extra_body=merged_extra_body,
+            incremental=incremental,
+            stream=stream,
+            debug=debug,
+            openrouter_provider=openrouter_provider,
+            api_format=api_format,
+        )
+        
+        await runner.validate_file(file_path)
+        
+        return {
+            "provider": provider_name,
+            "status": "success",
+            "summary": runner.summary,
+            "output_file": output_file,
+            "summary_file": summary_file,
+            "completed_at": datetime.now().isoformat(),
+        }
+    except Exception as e:
+        logger.error(f"Provider {provider_name} verification failed: {e}")
+        return {
+            "provider": provider_name,
+            "status": "failed",
+            "error": str(e),
+            "completed_at": datetime.now().isoformat(),
+        }
+
+
+async def batch_verify_providers(
+    provider_file: str,
+    test_file: str,
+    concurrency: int,
+    timeout: int,
+    max_retries: int,
+    output_dir: str,
+    incremental: bool,
+    parallel_providers: int = 1,
+    stream: bool = False,
+    debug: bool = False,
+    openrouter_provider: str = None,
+    api_format: str = "openai",
+    extra_body: dict = None,
+):
+    """Batch verify all providers"""
+    # Read provider configuration
+    with megfile.smart_open(provider_file, "r", encoding="utf-8") as f:
+        providers = json.load(f)
+    
+    logger.info(f"Loaded {len(providers)} provider configurations")
+    
+    # Ensure output directory exists
+    Path(output_dir).mkdir(parents=True, exist_ok=True)
+    
+    # If parallel_providers is 1, execute serially
+    if parallel_providers == 1:
+        results = []
+        for provider in providers:
+            result = await run_provider_verification(
+                provider,
+                test_file,
+                concurrency,
+                timeout,
+                max_retries,
+                output_dir,
+                incremental,
+                stream,
+                debug,
+                openrouter_provider,
+                api_format,
+                extra_body,
+            )
+            results.append(result)
+    else:
+        # Execute multiple providers in parallel
+        semaphore = asyncio.Semaphore(parallel_providers)
+        
+        async def run_with_semaphore(provider):
+            async with semaphore:
+                return await run_provider_verification(
+                    provider,
+                    test_file,
+                    concurrency,
+                    timeout,
+                    max_retries,
+                    output_dir,
+                    incremental,
+                    stream,
+                    debug,
+                    openrouter_provider,
+                    api_format,
+                    extra_body,
+                )
+        
+        tasks = [run_with_semaphore(provider) for provider in providers]
+        results = await asyncio.gather(*tasks)
+    
+    # Generate overall report
+    total_report = {
+        "test_file": test_file,
+        "total_providers": len(providers),
+        "successful_providers": sum(1 for r in results if r["status"] == "success"),
+        "failed_providers": sum(1 for r in results if r["status"] == "failed"),
+        "provider_results": results,
+        "generated_at": datetime.now().isoformat(),
+    }
+    
+    # Save overall report
+    report_file = os.path.join(output_dir, "batch_report.json")
+    with megfile.smart_open(report_file, "w", encoding="utf-8") as f:
+        json.dump(total_report, f, ensure_ascii=False, indent=2)
+    
+    logger.info("=" * 80)
+    logger.info("Batch verification completed!")
+    logger.info(f"Total providers: {total_report['total_providers']}")
+    logger.info(f"Successful: {total_report['successful_providers']}")
+    logger.info(f"Failed: {total_report['failed_providers']}")
+    logger.info(f"Overall report saved to: {report_file}")
+    logger.info("=" * 80)
+    
+    # Print summary for each provider
+    for result in results:
+        provider = result["provider"]
+        status = result["status"]
+        logger.info(f"\nProvider: {provider}")
+        logger.info(f"  Status: {status}")
+        
+        if status == "success" and "summary" in result:
+            summary = result["summary"]
+            logger.info(f"  Success count: {summary.get('success_count', 0)}")
+            logger.info(f"  Failure count: {summary.get('failure_count', 0)}")
+            
+            # Tool Calls Validator related statistics
+            if "tool_calls_successful_count" in summary:
+                logger.info(f"  Tool Calls successful: {summary.get('tool_calls_successful_count', 0)}")
+                logger.info(f"  Tool Calls schema validation errors: {summary.get('tool_calls_schema_validation_error_count', 0)}")
+                logger.info(f"  Tool Calls total count: {summary.get('tool_calls_total_count', 0)}")
+            
+        elif status == "failed":
+            logger.info(f"  Error: {result.get('error', 'Unknown error')}")
+
+
+async def main():
+    parser = argparse.ArgumentParser(
+        description="Batch verify capabilities of multiple LLM providers\n\n"
+        "Reads provider configurations from provider.json and runs verification tests for each provider.\n"
+        "Supports multiple validators to simultaneously verify tool calls, content length, and other dimensions."
+    )
+    
+    parser.add_argument(
+        "test_file",
+        help="Test data file path (JSONL format), e.g.: sample.jsonl",
+    )
+    
+    parser.add_argument(
+        "--provider-file",
+        default="provider.json",
+        help="Provider configuration file path (default: provider.json)",
+    )
+    
+    parser.add_argument(
+        "--output-dir",
+        default="batch_results",
+        help="Output directory (default: batch_results)",
+    )
+    
+    parser.add_argument(
+        "--max-workers",
+        type=int,
+        default=10,
+        dest="max_workers",
+        help="Maximum concurrent requests per provider (default: 10)",
+    )
+    
+    parser.add_argument(
+        "--parallel-providers",
+        type=int,
+        default=1,
+        help="Number of providers to run simultaneously (default: 1, meaning serial execution)",
+    )
+    
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=600,
+        help="Timeout per request in seconds (default: 600)",
+    )
+    
+    parser.add_argument(
+        "--retries",
+        type=int,
+        default=3,
+        help="Number of retries on failure (default: 3)",
+    )
+    
+    parser.add_argument(
+        "--incremental",
+        action="store_true",
+        help="Incremental mode: only rerun failed requests",
+    )
+    parser.add_argument(
+        "--stream",
+        action="store_true",
+        help="Use streaming mode for API requests (default: False)",
+    )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Debug mode: only run first 10 test cases (default: False)",
+    )
+    parser.add_argument(
+        "--openrouter-provider",
+        type=str,
+        default=None,
+        help="OpenRouter provider filter, e.g., 'fireworks'. Adds provider.only field to API requests.",
+    )
+    parser.add_argument(
+        "--api-format",
+        type=str,
+        choices=["openai", "anthropic"],
+        default="openai",
+        help="API format to use: 'openai' (default) or 'anthropic'. Use 'anthropic' for Claude models via Anthropic API.",
+    )
+    parser.add_argument(
+        "--extra-body",
+        type=str,
+        default=None,
+        help="Extra body parameters as JSON string, e.g., '{\"safety\": {\"input_level\": \"none\"}}'",
+    )
+    
+    args = parser.parse_args()
+    
+    # 解析 extra_body JSON 字符串
+    extra_body = None
+    if args.extra_body:
+        try:
+            extra_body = json.loads(args.extra_body)
+            logger.info(f"Using extra_body: {extra_body}")
+        except json.JSONDecodeError as e:
+            logger.error(f"Invalid JSON for --extra-body: {e}")
+            return
+    
+    await batch_verify_providers(
+        provider_file=args.provider_file,
+        test_file=args.test_file,
+        concurrency=args.max_workers,
+        timeout=args.timeout,
+        max_retries=args.retries,
+        output_dir=args.output_dir,
+        incremental=args.incremental,
+        parallel_providers=args.parallel_providers,
+        stream=args.stream,
+        debug=args.debug,
+        openrouter_provider=args.openrouter_provider,
+        api_format=args.api_format,
+        extra_body=extra_body,
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+

--- a/scripts/batch_verify.py
+++ b/scripts/batch_verify.py
@@ -34,7 +34,7 @@ async def run_provider_verification(
     summary_file = os.path.join(output_dir, f"{provider_name}_summary.json")
     
     try:
-        # 合并 extra_body：命令行参数优先级高于 provider_config
+        # Merge extra_body: command line arguments take precedence over provider_config
         merged_extra_body = provider_config.get("extra_body", {})
         if extra_body:
             merged_extra_body.update(extra_body)
@@ -282,7 +282,6 @@ async def main():
     
     args = parser.parse_args()
     
-    # 解析 extra_body JSON 字符串
     extra_body = None
     if args.extra_body:
         try:

--- a/scripts/calculate_batch_metrics.py
+++ b/scripts/calculate_batch_metrics.py
@@ -1,0 +1,664 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+Batch Metrics Calculation Script
+Reads all [provider]_summary.json files in the target folder and calculates key metrics
+
+Usage:
+    python3 scripts/calculate_batch_metrics.py --root-dir result4 --provider amazonaws
+"""
+
+import os
+import sys
+import json
+import glob
+from pathlib import Path
+from typing import Dict, List, Optional
+
+# Add scripts directory to Python path for running from project root
+SCRIPT_DIR = Path(__file__).parent.resolve()
+PROJECT_ROOT = SCRIPT_DIR.parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+# Import calculate_toolcall_similarity module
+from calculate_toolcall_similarity import calculate_tool_call_f1
+
+# Model version -> Reference data folder mapping
+REFERENCE_FOLDER_MAP = {
+    'M2.5': PROJECT_ROOT / 'MiniMax-M2.5',
+    'M2.7': PROJECT_ROOT / 'MiniMax-M2.7',
+    'M3':   PROJECT_ROOT / 'MiniMax-M3',
+}
+
+# Default sample.jsonl path
+DEFAULT_SAMPLE_FILE = PROJECT_ROOT / 'sample.jsonl'
+
+
+def get_expected_tool_call_count(sample_file: Path = None) -> dict:
+    """
+    Read sample.jsonl and count expected_tool_call values
+    Returns: {'true': count, 'false': count, 'total': count}
+    """
+    if sample_file is None:
+        sample_file = DEFAULT_SAMPLE_FILE
+    
+    if not sample_file.exists():
+        return {'true': 0, 'false': 0, 'total': 0}
+    
+    true_count = 0
+    false_count = 0
+    
+    with open(sample_file, 'r', encoding='utf-8') as f:
+        for line in f:
+            if line.strip():
+                data = json.loads(line)
+                val = data.get('expected_tool_call')
+                if val is True:
+                    true_count += 1
+                elif val is False:
+                    false_count += 1
+    
+    return {
+        'true': true_count,
+        'false': false_count,
+        'total': true_count + false_count
+    }
+
+
+def detect_model_version(model_name: str) -> Optional[str]:
+    """
+    Detect MiniMax version from model name, returns 'M2.5' / 'M2.7' / 'M3' or None
+    Supports common formats: minimax-m2.5-preview, MiniMax-M2.7, m3, etc.
+    """
+    if not model_name:
+        return None
+    name = model_name.lower()
+    if 'm3' in name or '3.0' in name:
+        return 'M3'
+    if 'm2.7' in name or '2.7' in name:
+        return 'M2.7'
+    if 'm2.5' in name or '2.5' in name:
+        return 'M2.5'
+    return None
+
+
+def load_minimax_reference_by_version(version: str) -> Optional[List[Dict]]:
+    """
+    Auto-locate reference folder by version and load minimax_results.jsonl
+    """
+    ref_dir = REFERENCE_FOLDER_MAP.get(version)
+    if ref_dir is None:
+        print(f"Warning: Reference folder not configured for version {version}")
+        return None
+    if not ref_dir.exists():
+        print(f"Warning: Reference folder does not exist: {ref_dir}")
+        return None
+
+    pattern = str(ref_dir / '**' / 'minimax_results.jsonl')
+    files = glob.glob(pattern, recursive=True)
+    if not files:
+        print(f"Warning: minimax_results.jsonl not found in {ref_dir}")
+        return None
+
+    ref_file = sorted(files)[0]
+    print(f"Using {version} reference file: {ref_file}")
+    return load_jsonl(ref_file)
+
+
+def calculate_average_token_usage(token_usage_list: List[Dict]) -> Dict:
+    """
+    Calculate average of multiple token_usage dictionaries
+    
+    Args:
+        token_usage_list: List of token_usage dictionaries
+    
+    Returns:
+        Averaged token_usage dictionary
+    """
+    if not token_usage_list:
+        return {}
+    
+    result = {}
+    token_types = ['prompt_tokens', 'completion_tokens', 'total_tokens', 'reasoning_tokens', 'cached_tokens']
+    
+    for token_type in token_types:
+        values = []
+        totals = []
+        for tu in token_usage_list:
+            if token_type in tu:
+                values.append(tu[token_type].get('average', 0))
+                totals.append(tu[token_type].get('total', 0))
+        
+        if values:
+            result[token_type] = {
+                'average': sum(values) / len(values),
+                'total': sum(totals),
+            }
+    
+    # Calculate sample count
+    samples_with_usage = sum(tu.get('samples_with_usage', 0) for tu in token_usage_list)
+    total_samples = sum(tu.get('total_samples', 0) for tu in token_usage_list)
+    result['samples_with_usage'] = samples_with_usage
+    result['total_samples'] = total_samples
+    
+    return result
+
+
+def find_summary_files(root_dir: str, provider: str = None) -> List[str]:
+    """
+    Recursively find all summary.json files matching naming convention
+    Naming convention: *_summary.json or {provider}_summary.json
+    
+    Args:
+        root_dir: Root directory path
+        provider: Specified provider name, if provided only find files for that provider
+    
+    Returns:
+        List of all found summary.json file paths
+    """
+    if provider:
+        # If provider specified, only find summary files for that provider
+        pattern = os.path.join(root_dir, "**", f"{provider}_summary.json")
+    else:
+        # Otherwise find all *_summary.json files
+        pattern = os.path.join(root_dir, "**", "*_summary.json")
+    
+    files = glob.glob(pattern, recursive=True)
+    return sorted(files)
+
+
+def load_summary_data(file_path: str) -> Dict:
+    """
+    Load summary.json file data
+    
+    Args:
+        file_path: File path
+    
+    Returns:
+        JSON data dictionary
+    """
+    try:
+        with open(file_path, 'r', encoding='utf-8') as f:
+            return json.load(f)
+    except Exception as e:
+        print(f"Error: Cannot read file {file_path}: {e}")
+        return None
+
+
+def load_jsonl(file_path: str) -> List[Dict]:
+    """
+    Load JSONL file
+    
+    Args:
+        file_path: File path
+    
+    Returns:
+        Data list
+    """
+    try:
+        data = []
+        with open(file_path, 'r', encoding='utf-8') as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    data.append(json.loads(line))
+        return data
+    except Exception as e:
+        print(f"Error: Cannot read file {file_path}: {e}")
+        return None
+
+
+def load_minimax_reference(root_dir: str) -> Optional[List[Dict]]:
+    """
+    Load minimax as reference data
+    
+    Args:
+        root_dir: Root directory path
+    
+    Returns:
+        minimax results data list, None if not found
+    """
+    # Find minimax_results.jsonl file (supports *minimax*_results.jsonl pattern)
+    pattern = os.path.join(root_dir, "**", "*minimax*_results.jsonl")
+    files = glob.glob(pattern, recursive=True)
+    
+    if not files:
+        print(f"Warning: minimax_results.jsonl not found, cannot calculate ToolCalls-Trigger Similarity")
+        return None
+    
+    # Use the first found file
+    minimax_file = files[0]
+    print(f"Using minimax reference file: {minimax_file}")
+    
+    return load_jsonl(minimax_file)
+
+
+def calculate_metrics(data: Dict, expected_tool_call_stats: dict = None) -> Dict:
+    """
+    Calculate metrics based on summary data
+    
+    Args:
+        data: summary.json data dictionary
+        expected_tool_call_stats: expected_tool_call statistics from sample.jsonl
+                                  {'true': count, 'false': count, 'total': count}
+    
+    Returns:
+        Calculated metrics dictionary
+    """
+    metrics = {}
+    
+    # 1. Query-Success-Rate = success_count / all_count
+    all_count = data.get('all_count', 0)
+    success_count = data.get('success_count', 0)
+    metrics['Query-Success-Rate'] = success_count / all_count if all_count > 0 else 0
+    
+    # 2. ToolCalls-Match-Rate = (tool_calls_finish_tool_calls + stop_finish_stop) / expected_tool_call_total_count
+    #    Denominator prioritizes expected_tool_call label count from sample.jsonl
+    tool_calls_finish_tool_calls = data.get('tool_calls_finish_tool_calls', 0)
+    stop_finish_stop = data.get('stop_finish_stop', 0)
+    
+    # Denominator priority: 1. External stats  2. Summary stats  3. success_count
+    if expected_tool_call_stats and expected_tool_call_stats.get('total', 0) > 0:
+        match_rate_denominator = expected_tool_call_stats['total']
+    elif data.get('expected_tool_call_total_count', 0) > 0:
+        match_rate_denominator = data['expected_tool_call_total_count']
+    else:
+        match_rate_denominator = success_count
+    
+    metrics['ToolCalls-Match-Rate'] = (tool_calls_finish_tool_calls + stop_finish_stop) / match_rate_denominator if match_rate_denominator > 0 else 0
+    
+    # 3. ToolCalls-Accuracy = tool_calls_successful_count / tool_calls_finish_tool_calls
+    tool_calls_successful_count = data.get('tool_calls_successful_count', 0)
+    metrics['ToolCalls-Accuracy'] = tool_calls_successful_count / tool_calls_finish_tool_calls if tool_calls_finish_tool_calls > 0 else 0
+    
+    # 4. Response Success Rate-Not Only Reasoning = error_only_reasoning_count / error_only_reasoning_checked_count
+    # Note: This metric is actually error rate, success rate should be 1 - this value
+    # But as per user request, we calculate error_only_reasoning_count / error_only_reasoning_checked_count
+    error_only_reasoning_count = data.get('error_only_reasoning_count', 0)
+    error_only_reasoning_checked_count = data.get('error_only_reasoning_checked_count', 0)
+    metrics['Response-Success-Rate-Not-Only-Reasoning'] = (error_only_reasoning_checked_count - error_only_reasoning_count) / error_only_reasoning_checked_count if error_only_reasoning_checked_count > 0 else 0
+    
+    # 5. Language-Following-Success-Rate = language_following_valid_count / language_following_checked_count
+    language_following_valid_count = data.get('language_following_valid_count', 0)
+    language_following_checked_count = data.get('language_following_checked_count', 0)
+    metrics['Language-Following-Success-Rate'] = language_following_valid_count / language_following_checked_count if language_following_checked_count > 0 else 0
+    
+    # 6. Token Usage Statistics (if available)
+    token_usage = data.get('token_usage', {})
+    if token_usage:
+        metrics['token_usage'] = {}
+        # Extract average values for each token type
+        for token_type in ['prompt_tokens', 'completion_tokens', 'total_tokens', 'reasoning_tokens', 'cached_tokens']:
+            if token_type in token_usage:
+                metrics['token_usage'][token_type] = {
+                    'average': token_usage[token_type].get('average', 0),
+                    'total': token_usage[token_type].get('total', 0),
+                    'min': token_usage[token_type].get('min', 0),
+                    'max': token_usage[token_type].get('max', 0),
+                }
+        metrics['token_usage']['samples_with_usage'] = token_usage.get('samples_with_usage', 0)
+        metrics['token_usage']['total_samples'] = token_usage.get('total_samples', 0)
+    
+    return metrics
+
+
+def print_file_metrics(file_path: str, data: Dict, metrics: Dict):
+    """
+    Print metrics for a single file
+    """
+    model = data.get('model', 'Unknown')
+    print(f"\n{'='*80}")
+    print(f"File: {file_path}")
+    print(f"Model: {model}")
+    print(f"{'-'*80}")
+    print(f"Raw Data:")
+    print(f"  - Total queries (all_count): {data.get('all_count', 0)}")
+    print(f"  - Success count (success_count): {data.get('success_count', 0)}")
+    print(f"  - Failure count (failure_count): {data.get('failure_count', 0)}")
+    print(f"  - ToolCalls finish count (tool_calls_finish_tool_calls): {data.get('tool_calls_finish_tool_calls', 0)}")
+    print(f"  - ToolCalls success count (tool_calls_successful_count): {data.get('tool_calls_successful_count', 0)}")
+    print(f"  - Only reasoning error checked (error_only_reasoning_checked_count): {data.get('error_only_reasoning_checked_count', 0)}")
+    print(f"  - Only reasoning error count (error_only_reasoning_count): {data.get('error_only_reasoning_count', 0)}")
+    print(f"  - Language following checked (language_following_checked_count): {data.get('language_following_checked_count', 0)}")
+    print(f"  - Language following valid (language_following_valid_count): {data.get('language_following_valid_count', 0)}")
+    print(f"{'-'*80}")
+    print(f"Calculated Metrics:")
+    print(f"  1. Query-Success-Rate: {metrics['Query-Success-Rate']:.4f} ({metrics['Query-Success-Rate']*100:.2f}%)")
+    print(f"  2. ToolCalls-Match-Rate: {metrics['ToolCalls-Match-Rate']:.4f} ({metrics['ToolCalls-Match-Rate']*100:.2f}%)")
+    if metrics.get('ToolCalls-Trigger-Similarity-F1') is not None:
+        print(f"  3. ToolCalls-Trigger-Similarity-F1: {metrics['ToolCalls-Trigger-Similarity-F1']:.4f} ({metrics['ToolCalls-Trigger-Similarity-F1']*100:.2f}%)")
+    print(f"  4. ToolCalls-Accuracy: {metrics['ToolCalls-Accuracy']:.4f} ({metrics['ToolCalls-Accuracy']*100:.2f}%)")
+    print(f"  5. Response-Success-Rate-Not-Only-Reasoning: {metrics['Response-Success-Rate-Not-Only-Reasoning']:.4f} ({metrics['Response-Success-Rate-Not-Only-Reasoning']*100:.2f}%)")
+    print(f"  6. Language-Following-Success-Rate: {metrics['Language-Following-Success-Rate']:.4f} ({metrics['Language-Following-Success-Rate']*100:.2f}%)")
+    
+    # Print token usage statistics if available
+    token_usage = metrics.get('token_usage')
+    if token_usage:
+        print(f"{'-'*80}")
+        print(f"Token Usage Statistics (samples: {token_usage.get('samples_with_usage', 0)}/{token_usage.get('total_samples', 0)}):")
+        if 'prompt_tokens' in token_usage:
+            pt = token_usage['prompt_tokens']
+            print(f"  - Prompt Tokens: avg {pt['average']:.2f}, total {pt['total']}, range [{pt['min']}, {pt['max']}]")
+        if 'completion_tokens' in token_usage:
+            ct = token_usage['completion_tokens']
+            print(f"  - Completion Tokens: avg {ct['average']:.2f}, total {ct['total']}, range [{ct['min']}, {ct['max']}]")
+        if 'reasoning_tokens' in token_usage:
+            rt = token_usage['reasoning_tokens']
+            print(f"  - Reasoning Tokens: avg {rt['average']:.2f}, total {rt['total']}, range [{rt['min']}, {rt['max']}]")
+        if 'total_tokens' in token_usage:
+            tt = token_usage['total_tokens']
+            print(f"  - Total Tokens: avg {tt['average']:.2f}, total {tt['total']}, range [{tt['min']}, {tt['max']}]")
+        if 'cached_tokens' in token_usage:
+            cct = token_usage['cached_tokens']
+            print(f"  - Cached Tokens: avg {cct['average']:.2f}, total {cct['total']}, range [{cct['min']}, {cct['max']}]")
+    
+    print(f"{'='*80}")
+
+
+def print_summary_table(all_results: List[Dict]):
+    """
+    Print summary table
+    """
+    print(f"\n\n{'='*120}")
+    print(f"Summary Table")
+    print(f"{'='*120}")
+    
+    # Check if ToolCalls-Trigger Similarity data exists
+    has_similarity = any(r['metrics'].get('ToolCalls-Trigger-Similarity-F1') is not None for r in all_results)
+    
+    # Header
+    if has_similarity:
+        print(f"\n{'File':<40} {'Model':<30} {'Q-Succ':<10} {'TC-Match':<10} {'TC-Sim-F1':<12} {'Tool-Acc':<10} {'R-Succ':<10} {'Lang-Succ':<10}")
+        print(f"{'-'*120}")
+    else:
+        print(f"\n{'File':<40} {'Model':<30} {'Q-Succ':<10} {'TC-Match':<10} {'Tool-Acc':<10} {'R-Succ':<10} {'Lang-Succ':<10}")
+        print(f"{'-'*100}")
+    
+    # Data rows
+    for result in all_results:
+        file_name = os.path.basename(result['file_path'])
+        model = result['data'].get('model', 'Unknown')
+        if len(model) > 28:
+            model = model[:25] + "..."
+        metrics = result['metrics']
+        
+        if has_similarity:
+            sim_f1 = metrics.get('ToolCalls-Trigger-Similarity-F1')
+            sim_str = f"{sim_f1*100:>10.2f}%" if sim_f1 is not None else "N/A".rjust(12)
+            print(f"{file_name:<40} {model:<30} {metrics['Query-Success-Rate']*100:>8.2f}% {metrics['ToolCalls-Match-Rate']*100:>8.2f}% {sim_str} {metrics['ToolCalls-Accuracy']*100:>8.2f}% {metrics['Response-Success-Rate-Not-Only-Reasoning']*100:>8.2f}% {metrics['Language-Following-Success-Rate']*100:>8.2f}%")
+        else:
+            print(f"{file_name:<40} {model:<30} {metrics['Query-Success-Rate']*100:>8.2f}% {metrics['ToolCalls-Match-Rate']*100:>8.2f}% {metrics['ToolCalls-Accuracy']*100:>8.2f}% {metrics['Response-Success-Rate-Not-Only-Reasoning']*100:>8.2f}% {metrics['Language-Following-Success-Rate']*100:>8.2f}%")
+    
+    if has_similarity:
+        print(f"{'='*120}")
+    else:
+        print(f"{'='*100}")
+    
+    # Calculate averages
+    if all_results:
+        avg_metrics = {
+            'Query-Success-Rate': sum(r['metrics']['Query-Success-Rate'] for r in all_results) / len(all_results),
+            'ToolCalls-Match-Rate': sum(r['metrics']['ToolCalls-Match-Rate'] for r in all_results) / len(all_results),
+            'ToolCalls-Accuracy': sum(r['metrics']['ToolCalls-Accuracy'] for r in all_results) / len(all_results),
+            'Response-Success-Rate-Not-Only-Reasoning': sum(r['metrics']['Response-Success-Rate-Not-Only-Reasoning'] for r in all_results) / len(all_results),
+            'Language-Following-Success-Rate': sum(r['metrics']['Language-Following-Success-Rate'] for r in all_results) / len(all_results),
+        }
+        
+        # Calculate ToolCalls-Trigger Similarity average
+        if has_similarity:
+            sim_values = [r['metrics']['ToolCalls-Trigger-Similarity-F1'] for r in all_results if r['metrics'].get('ToolCalls-Trigger-Similarity-F1') is not None]
+            if sim_values:
+                avg_metrics['ToolCalls-Trigger-Similarity-F1'] = sum(sim_values) / len(sim_values)
+        
+        print(f"\nAverages:")
+        print(f"  1. Query-Success-Rate: {avg_metrics['Query-Success-Rate']:.4f} ({avg_metrics['Query-Success-Rate']*100:.2f}%)")
+        print(f"  2. ToolCalls-Match-Rate: {avg_metrics['ToolCalls-Match-Rate']:.4f} ({avg_metrics['ToolCalls-Match-Rate']*100:.2f}%)")
+        if has_similarity and 'ToolCalls-Trigger-Similarity-F1' in avg_metrics:
+            print(f"  3. ToolCalls-Trigger-Similarity-F1: {avg_metrics['ToolCalls-Trigger-Similarity-F1']:.4f} ({avg_metrics['ToolCalls-Trigger-Similarity-F1']*100:.2f}%)")
+        print(f"  4. ToolCalls-Accuracy: {avg_metrics['ToolCalls-Accuracy']:.4f} ({avg_metrics['ToolCalls-Accuracy']*100:.2f}%)")
+        print(f"  5. Response-Success-Rate-Not-Only-Reasoning: {avg_metrics['Response-Success-Rate-Not-Only-Reasoning']:.4f} ({avg_metrics['Response-Success-Rate-Not-Only-Reasoning']*100:.2f}%)")
+        print(f"  6. Language-Following-Success-Rate: {avg_metrics['Language-Following-Success-Rate']:.4f} ({avg_metrics['Language-Following-Success-Rate']*100:.2f}%)")
+        
+        # Calculate Token usage averages
+        token_usage_results = [r['metrics'].get('token_usage') for r in all_results if r['metrics'].get('token_usage')]
+        if token_usage_results:
+            print(f"\n  Token Usage Statistics Averages:")
+            avg_token_usage = calculate_average_token_usage(token_usage_results)
+            if 'prompt_tokens' in avg_token_usage:
+                print(f"    - Avg Prompt Tokens: {avg_token_usage['prompt_tokens']['average']:.2f}")
+            if 'completion_tokens' in avg_token_usage:
+                print(f"    - Avg Completion Tokens: {avg_token_usage['completion_tokens']['average']:.2f}")
+            if 'reasoning_tokens' in avg_token_usage:
+                print(f"    - Avg Reasoning Tokens: {avg_token_usage['reasoning_tokens']['average']:.2f}")
+            if 'total_tokens' in avg_token_usage:
+                print(f"    - Avg Total Tokens: {avg_token_usage['total_tokens']['average']:.2f}")
+            if 'cached_tokens' in avg_token_usage:
+                print(f"    - Avg Cached Tokens: {avg_token_usage['cached_tokens']['average']:.2f}")
+
+
+def main():
+    """Main function"""
+    import argparse
+    
+    parser = argparse.ArgumentParser(description='Batch calculate metrics')
+    parser.add_argument('--root-dir', type=str, default='.',
+                        help='Root directory path, defaults to current directory')
+    parser.add_argument('--provider', type=str, default=None,
+                        help='Specify provider name, only calculate files for that provider, i.e. {provider}_summary.json')
+    parser.add_argument('--detailed', action='store_true',
+                        help='Whether to show detailed information')
+    parser.add_argument('--output', type=str, default=None,
+                        help='Output results to JSON file')
+    parser.add_argument('--sample-file', type=str, default=None,
+                        help='sample.jsonl file path, used to count expected_tool_call as Match-Rate denominator')
+    
+    args = parser.parse_args()
+    
+    # Read expected_tool_call statistics (for Match-Rate denominator)
+    sample_file = Path(args.sample_file) if args.sample_file else DEFAULT_SAMPLE_FILE
+    expected_tool_call_stats = get_expected_tool_call_count(sample_file)
+    if expected_tool_call_stats['total'] > 0:
+        print(f"Read expected_tool_call statistics from {sample_file}:")
+        print(f"  - expected_tool_call=True: {expected_tool_call_stats['true']}")
+        print(f"  - expected_tool_call=False: {expected_tool_call_stats['false']}")
+        print(f"  - Total (Match-Rate denominator): {expected_tool_call_stats['total']}")
+    
+    # Find all summary files
+    print(f"Searching directory: {os.path.abspath(args.root_dir)}")
+    if args.provider:
+        print(f"Specified provider: {args.provider}")
+    
+    summary_files = find_summary_files(args.root_dir, args.provider)
+    
+    print(f"\nTotal {len(summary_files)} files found")
+    
+    if len(summary_files) == 0:
+        if args.provider:
+            print(f"No {args.provider}_summary.json files found")
+        else:
+            print("No *_summary.json files found")
+        return
+    
+    print("\nFiles found:")
+    for i, file_path in enumerate(summary_files, 1):
+        print(f"  {i}. {file_path}")
+    
+    # Process each file
+    all_results = []
+    # Cache reference data by version to avoid duplicate loading
+    reference_cache: Dict[str, Optional[List[Dict]]] = {}
+
+    for file_path in summary_files:
+        data = load_summary_data(file_path)
+        if data is None:
+            continue
+
+        metrics = calculate_metrics(data, expected_tool_call_stats)
+
+        result = {
+            'file_path': file_path,
+            'data': data,
+            'metrics': metrics
+        }
+
+        # Calculate ToolCalls-Trigger-Similarity-F1
+        # Skip condition: specified provider is minimax itself
+        is_minimax_self = args.provider and args.provider.lower() == 'minimax'
+        if not is_minimax_self:
+            results_file = file_path.replace('_summary.json', '_results.jsonl')
+            if os.path.exists(results_file):
+                model_results = load_jsonl(results_file)
+                if model_results is not None:
+                    # Auto-detect version from model name, select corresponding reference folder
+                    model_name = data.get('model', '')
+                    version = detect_model_version(model_name)
+                    if version is None:
+                        # Fallback: search in root_dir using old logic
+                        print(f"Warning: Cannot detect version from model name '{model_name}', trying to find reference data in root_dir")
+                        version = '__legacy__'
+
+                    if version not in reference_cache:
+                        if version == '__legacy__':
+                            reference_cache[version] = load_minimax_reference(args.root_dir)
+                        else:
+                            reference_cache[version] = load_minimax_reference_by_version(version)
+
+                    minimax_reference = reference_cache[version]
+
+                    if minimax_reference is not None:
+                        try:
+                            min_len = min(len(minimax_reference), len(model_results))
+                            if len(minimax_reference) != len(model_results):
+                                print(f"Warning: Sample count mismatch (minimax: {len(minimax_reference)}, model: {len(model_results)}), using first {min_len} samples for calculation")
+                            ref_subset = minimax_reference[:min_len]
+                            model_subset = model_results[:min_len]
+
+                            f1_metrics = calculate_tool_call_f1(ref_subset, model_subset)
+                            result['toolcalls_trigger_similarity'] = {
+                                'f1': f1_metrics['f1'],
+                                'precision': f1_metrics['precision'],
+                                'recall': f1_metrics['recall'],
+                                'tp': f1_metrics['tp'],
+                                'fp': f1_metrics['fp'],
+                                'fn': f1_metrics['fn'],
+                                'tn': f1_metrics['tn'],
+                                'samples_used': min_len,
+                                'reference_version': version,
+                            }
+                            metrics['ToolCalls-Trigger-Similarity-F1'] = f1_metrics['f1']
+                        except Exception as e:
+                            print(f"Warning: Error calculating ToolCalls-Trigger Similarity for {file_path}: {e}")
+                            metrics['ToolCalls-Trigger-Similarity-F1'] = None
+                    else:
+                        metrics['ToolCalls-Trigger-Similarity-F1'] = None
+            else:
+                print(f"Warning: Corresponding results file not found: {results_file}")
+                metrics['ToolCalls-Trigger-Similarity-F1'] = None
+        else:
+            metrics['ToolCalls-Trigger-Similarity-F1'] = None
+
+        all_results.append(result)
+        
+        if args.detailed:
+            print_file_metrics(file_path, data, metrics)
+    
+    # Print summary table
+    print_summary_table(all_results)
+    
+    # Save to file
+    if args.output:
+        # Calculate averages
+        avg_metrics = {}
+        if all_results:
+            avg_metrics_raw = {
+                'Query-Success-Rate': sum(r['metrics']['Query-Success-Rate'] for r in all_results) / len(all_results),
+                'ToolCalls-Match-Rate': sum(r['metrics']['ToolCalls-Match-Rate'] for r in all_results) / len(all_results),
+                'ToolCalls-Accuracy': sum(r['metrics']['ToolCalls-Accuracy'] for r in all_results) / len(all_results),
+                'Response-Success-Rate-Not-Only-Reasoning': sum(r['metrics']['Response-Success-Rate-Not-Only-Reasoning'] for r in all_results) / len(all_results),
+                'Language-Following-Success-Rate': sum(r['metrics']['Language-Following-Success-Rate'] for r in all_results) / len(all_results),
+            }
+            
+            # Calculate ToolCalls-Trigger Similarity average
+            sim_values = [r['metrics']['ToolCalls-Trigger-Similarity-F1'] for r in all_results if r['metrics'].get('ToolCalls-Trigger-Similarity-F1') is not None]
+            if sim_values:
+                avg_metrics_raw['ToolCalls-Trigger-Similarity-F1'] = sum(sim_values) / len(sim_values)
+            
+            # Calculate Token usage averages
+            token_usage_results = [r['metrics'].get('token_usage') for r in all_results if r['metrics'].get('token_usage')]
+            if token_usage_results:
+                avg_metrics_raw['token_usage'] = calculate_average_token_usage(token_usage_results)
+            
+            # Reorganize averages with numbered prefix in specified order
+            avg_metrics = {
+                '1. Query-Success-Rate': avg_metrics_raw['Query-Success-Rate'],
+                '2. ToolCalls-Match-Rate': avg_metrics_raw['ToolCalls-Match-Rate'],
+            }
+            
+            # Add ToolCalls-Trigger-Similarity-F1 (if exists)
+            if 'ToolCalls-Trigger-Similarity-F1' in avg_metrics_raw:
+                avg_metrics['3. ToolCalls-Trigger-Similarity-F1'] = avg_metrics_raw['ToolCalls-Trigger-Similarity-F1']
+            
+            avg_metrics.update({
+                '4. ToolCalls-Accuracy': avg_metrics_raw['ToolCalls-Accuracy'],
+                '5. Response-Success-Rate-Not-Only-Reasoning': avg_metrics_raw['Response-Success-Rate-Not-Only-Reasoning'],
+                '6. Language-Following-Success-Rate': avg_metrics_raw['Language-Following-Success-Rate']
+            })
+            
+            # Add Token usage statistics (if exists)
+            if 'token_usage' in avg_metrics_raw:
+                avg_metrics['7. Token-Usage'] = avg_metrics_raw['token_usage']
+        
+        # Build output data structure
+        output_data = {
+            'summary': {
+                'total_files': len(all_results),
+                'average_metrics': avg_metrics
+            },
+            'results': []
+        }
+        
+        for result in all_results:
+            metrics = result['metrics']
+            
+            # Reorganize metrics with numbered prefix in specified order
+            ordered_metrics = {
+                '1. Query-Success-Rate': metrics['Query-Success-Rate'],
+                '2. ToolCalls-Match-Rate': metrics['ToolCalls-Match-Rate'],
+            }
+            
+            # Add ToolCalls-Trigger-Similarity-F1 (if exists)
+            if metrics.get('ToolCalls-Trigger-Similarity-F1') is not None:
+                ordered_metrics['3. ToolCalls-Trigger-Similarity-F1'] = metrics['ToolCalls-Trigger-Similarity-F1']
+            
+            ordered_metrics.update({
+                '4. ToolCalls-Accuracy': metrics['ToolCalls-Accuracy'],
+                '5. Response-Success-Rate-Not-Only-Reasoning': metrics['Response-Success-Rate-Not-Only-Reasoning'],
+                '6. Language-Following-Success-Rate': metrics['Language-Following-Success-Rate']
+            })
+            
+            # Add Token usage statistics (if exists)
+            if metrics.get('token_usage'):
+                ordered_metrics['7. Token-Usage'] = metrics['token_usage']
+            
+            result_data = {
+                'file': result['file_path'],
+                'model': result['data'].get('model', 'Unknown'),
+                'metrics': ordered_metrics
+            }
+            
+            # Include ToolCalls-Trigger Similarity detailed data if available
+            if 'toolcalls_trigger_similarity' in result:
+                result_data['toolcalls_trigger_similarity'] = result['toolcalls_trigger_similarity']
+            
+            output_data['results'].append(result_data)
+        
+        with open(args.output, 'w', encoding='utf-8') as f:
+            json.dump(output_data, f, indent=4, ensure_ascii=False)
+        
+        print(f"\nResults saved to: {args.output}")
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/calculate_toolcall_similarity.py
+++ b/scripts/calculate_toolcall_similarity.py
@@ -1,0 +1,726 @@
+#!/usr/bin/env python3
+"""
+Calculate tool call similarity metrics:
+1. ToolCall-Trigger Similarity (tool_call_f1)
+2. Multi-ToolCall-Trigger Similarity (based on Cosine similarity)
+3. ToolCall-Accuracy (tool call success rate)
+4. Validation Metrics (error_repeating, language_following)
+5. Error Only Reasoning (errors containing only reasoning)
+"""
+
+import json
+import os
+import glob
+from typing import Dict, List, Tuple, Optional
+from pathlib import Path
+import numpy as np
+import argparse
+
+
+def load_jsonl(file_path: str) -> List[Dict]:
+    """Load JSONL file"""
+    data = []
+    with open(file_path, 'r', encoding='utf-8') as f:
+        for line in f:
+            data.append(json.loads(line.strip()))
+    return data
+
+
+def load_summary(file_path: str) -> Dict:
+    """Load summary JSON file"""
+    with open(file_path, 'r', encoding='utf-8') as f:
+        return json.load(f)
+
+
+def discover_models(folder_path: str) -> Dict[str, Dict[str, str]]:
+    """
+    Scan folder to discover summary and results files for all models
+    
+    Args:
+        folder_path: Folder path containing result files
+    
+    Returns:
+        {
+            'model_name': {
+                'summary': '/path/to/model_summary.json',
+                'results': '/path/to/model_results.jsonl'
+            },
+            ...
+        }
+    """
+    models = {}
+    folder_path = Path(folder_path)
+    
+    # Find all *_summary.json files
+    summary_files = glob.glob(str(folder_path / '*_summary.json'))
+    
+    for summary_file in summary_files:
+        summary_file = Path(summary_file)
+        filename = summary_file.stem  # Remove extension
+        
+        # Extract model name (part before _summary)
+        if filename.endswith('_summary'):
+            model_name = filename[:-8]  # Remove '_summary'
+        else:
+            continue
+        
+        # Find corresponding results.jsonl file
+        results_file = folder_path / f'{model_name}_results.jsonl'
+        
+        if results_file.exists():
+            models[model_name] = {
+                'summary': str(summary_file),
+                'results': str(results_file)
+            }
+        else:
+            print(f"Warning: Found {summary_file.name} but not corresponding {model_name}_results.jsonl")
+    
+    return models
+
+
+def get_finish_reason(result: Dict) -> str:
+    """Get finish_reason, always return a string"""
+    try:
+        if not result or 'response' not in result:
+            return 'error_no_response'
+        
+        response = result.get('response')
+        if response is None:
+            return 'error_response_none'
+        
+        choices = response.get('choices')
+        if choices is None:
+            return 'error_choices_none'
+        
+        if len(choices) == 0:
+            return 'error_choices_empty'
+        
+        finish_reason = choices[0].get('finish_reason')
+        if finish_reason is None:
+            return 'error_no_finish_reason'
+        
+        return str(finish_reason)
+    except (KeyError, IndexError, TypeError, AttributeError) as e:
+        return f'error_exception_{type(e).__name__}'
+
+
+def calculate_tool_call_f1(official_results: List[Dict], model_results: List[Dict]) -> Dict:
+    """
+    Calculate ToolCall-Trigger Similarity (tool_call_f1)
+    
+    Args:
+        official_results: Gold standard results
+        model_results: Model results to evaluate
+    
+    Returns:
+        Dict containing TP, FP, FN, TN, precision, recall, f1
+    """
+    if len(official_results) != len(model_results):
+        raise ValueError(f"Sample count mismatch: gold standard {len(official_results)}, evaluated {len(model_results)}")
+    
+    tp = fp = fn = tn = 0
+    error_count = 0
+    error_detail = {}
+    
+    for official, model in zip(official_results, model_results):
+        official_reason = get_finish_reason(official)
+        model_reason = get_finish_reason(model)
+        
+        # Count error cases
+        if model_reason.startswith('error_'):
+            error_count += 1
+            error_detail[model_reason] = error_detail.get(model_reason, 0) + 1
+        
+        official_is_tool_call = (official_reason == 'tool_calls')
+        model_is_tool_call = (model_reason == 'tool_calls')
+        
+        if official_is_tool_call and model_is_tool_call:
+            tp += 1
+        elif not official_is_tool_call and model_is_tool_call:
+            fp += 1
+        elif official_is_tool_call and not model_is_tool_call:
+            fn += 1
+        else:
+            tn += 1
+    
+    precision = tp / (tp + fp) if (tp + fp) > 0 else 0
+    recall = tp / (tp + fn) if (tp + fn) > 0 else 0
+    f1 = 2 * precision * recall / (precision + recall) if (precision + recall) > 0 else 0
+    
+    return {
+        'tp': tp,
+        'fp': fp,
+        'fn': fn,
+        'tn': tn,
+        'precision': precision,
+        'recall': recall,
+        'f1': f1,
+        'total_samples': len(official_results),
+        'error_count': error_count,
+        'error_detail': error_detail
+    }
+
+
+def normalize_distribution(dist_dict: Dict[str, int]) -> Tuple[List[int], List[float]]:
+    """
+    Normalize distribution dict to probability distribution
+    
+    Args:
+        dist_dict: {"1": 20, "2": 15, ...}
+    
+    Returns:
+        (keys, probabilities): Sorted key list and corresponding probability list
+    """
+    keys = sorted([int(k) for k in dist_dict.keys()])
+    counts = [dist_dict[str(k)] for k in keys]
+    total = sum(counts)
+    
+    if total == 0:
+        return keys, [0.0] * len(keys)
+    
+    probs = [count / total for count in counts]
+    return keys, probs
+
+
+def align_distributions(keys1: List[int], probs1: List[float], 
+                        keys2: List[int], probs2: List[float]) -> Tuple[List[int], List[float], List[float]]:
+    """Align two distributions to ensure they have the same keys"""
+    all_keys = sorted(set(keys1 + keys2))
+    
+    dict1 = dict(zip(keys1, probs1))
+    dict2 = dict(zip(keys2, probs2))
+    
+    aligned_probs1 = [dict1.get(k, 0.0) for k in all_keys]
+    aligned_probs2 = [dict2.get(k, 0.0) for k in all_keys]
+    
+    return all_keys, aligned_probs1, aligned_probs2
+
+
+def cosine_similarity(probs1: List[float], probs2: List[float]) -> float:
+    """
+    Calculate cosine similarity
+    
+    Returns:
+        Similarity in range [0, 1], 1 means identical
+    """
+    vec1 = np.array(probs1)
+    vec2 = np.array(probs2)
+    
+    norm1 = np.linalg.norm(vec1)
+    norm2 = np.linalg.norm(vec2)
+    
+    if norm1 == 0 or norm2 == 0:
+        return 0.0
+    
+    cos_sim = np.dot(vec1, vec2) / (norm1 * norm2)
+    return float(cos_sim)
+
+
+def calculate_toolcall_accuracy(summary: Dict) -> Dict:
+    """
+    Calculate ToolCall-Accuracy (tool call success rate)
+    
+    Args:
+        summary: Model's summary data
+    
+    Returns:
+        Dict containing success rate metrics
+    """
+    tool_calls_finish = summary.get('tool_calls_finish_tool_calls', 0)
+    tool_calls_successful = summary.get('tool_calls_successful_count', 0)
+    
+    accuracy = tool_calls_successful / tool_calls_finish if tool_calls_finish > 0 else 0.0
+    
+    return {
+        'accuracy': accuracy,
+        'tool_calls_successful_count': tool_calls_successful,
+        'tool_calls_finish_tool_calls': tool_calls_finish
+    }
+
+
+def calculate_error_only_reasoning(results: List[Dict]) -> Dict:
+    """
+    Check if there are errors with only reasoning while content and tool_calls are empty
+    
+    Args:
+        results: Model's result list
+    
+    Returns:
+        Dict containing error_only_reasoning statistics
+    """
+    error_only_reasoning_count = 0
+    total_checked = len(results)
+    
+    for result in results:
+        try:
+            if not result or 'response' not in result:
+                continue
+            
+            response = result.get('response')
+            if response is None:
+                continue
+            
+            choices = response.get('choices')
+            if choices is None or len(choices) == 0:
+                continue
+            
+            message = choices[0].get('message')
+            if message is None:
+                continue
+            
+            # Check reasoning, content, tool_calls
+            reasoning = message.get('reasoning', '')
+            content = message.get('content', '')
+            tool_calls = message.get('tool_calls', [])
+            
+            # If reasoning has content, but content and tool_calls are empty
+            if reasoning and not content and not tool_calls:
+                error_only_reasoning_count += 1
+                
+        except (KeyError, IndexError, TypeError, AttributeError):
+            continue
+    
+    error_only_reasoning_rate = error_only_reasoning_count / total_checked if total_checked > 0 else 0.0
+    
+    return {
+        'error_only_reasoning_count': error_only_reasoning_count,
+        'total_checked': total_checked,
+        'error_only_reasoning_rate': error_only_reasoning_rate
+    }
+
+
+def calculate_validation_metrics(summary: Dict) -> Dict:
+    """
+    Calculate validation metrics (error_repeating and language_following)
+    
+    Args:
+        summary: Model's summary data
+    
+    Returns:
+        Dict containing validation metrics
+    """
+    # error_repeating metrics
+    error_repeating_checked = summary.get('error_repeating_checked_count', 0)
+    error_repeating_valid = summary.get('error_repeating_valid_count', 0)
+    error_repeating_invalid = summary.get('error_repeating_invalid_count', 0)
+    
+    error_repeating_success_rate = error_repeating_valid / error_repeating_checked if error_repeating_checked > 0 else 0.0
+    
+    # language_following metrics
+    language_following_checked = summary.get('language_following_checked_count', 0)
+    language_following_valid = summary.get('language_following_valid_count', 0)
+    language_following_invalid = summary.get('language_following_invalid_count', 0)
+    
+    language_following_success_rate = language_following_valid / language_following_checked if language_following_checked > 0 else 0.0
+    
+    # Overall success rate (sum of two validation rules)
+    total_checked = error_repeating_checked + language_following_checked
+    total_valid = error_repeating_valid + language_following_valid
+    total_invalid = error_repeating_invalid + language_following_invalid
+    
+    overall_success_rate = total_valid / total_checked if total_checked > 0 else 0.0
+    
+    return {
+        'error_repeating': {
+            'checked_count': error_repeating_checked,
+            'valid_count': error_repeating_valid,
+            'invalid_count': error_repeating_invalid,
+            'success_rate': error_repeating_success_rate
+        },
+        'language_following': {
+            'checked_count': language_following_checked,
+            'valid_count': language_following_valid,
+            'invalid_count': language_following_invalid,
+            'success_rate': language_following_success_rate
+        },
+        'overall': {
+            'total_checked': total_checked,
+            'total_valid': total_valid,
+            'total_invalid': total_invalid,
+            'overall_success_rate': overall_success_rate
+        }
+    }
+
+
+def calculate_multi_toolcall_similarity(official_dist: Dict[str, int], 
+                                       model_dist: Dict[str, int]) -> Dict:
+    """
+    Calculate Multi-ToolCall-Trigger Similarity (based on Cosine similarity)
+    
+    Args:
+        official_dist: Gold standard's tool_calls_count_distribution
+        model_dist: Evaluated model's tool_calls_count_distribution
+    
+    Returns:
+        Dict containing similarity metrics and distribution comparison
+    """
+    # Normalize distributions
+    keys1, probs1 = normalize_distribution(official_dist)
+    keys2, probs2 = normalize_distribution(model_dist)
+    
+    # Align distributions
+    all_keys, aligned_probs1, aligned_probs2 = align_distributions(keys1, probs1, keys2, probs2)
+    
+    # Calculate Cosine similarity
+    similarity = cosine_similarity(aligned_probs1, aligned_probs2)
+    
+    # Build detailed distribution comparison
+    distribution_comparison = []
+    for key, prob1, prob2 in zip(all_keys, aligned_probs1, aligned_probs2):
+        count1 = official_dist.get(str(key), 0)
+        count2 = model_dist.get(str(key), 0)
+        distribution_comparison.append({
+            'tool_calls_count': key,
+            'official_count': count1,
+            'official_prob': prob1,
+            'model_count': count2,
+            'model_prob': prob2,
+            'prob_diff': prob2 - prob1
+        })
+    
+    return {
+        'cosine_similarity': similarity,
+        'distribution_comparison': distribution_comparison
+    }
+
+
+def print_results(model_name: str, f1_metrics: Dict, multi_metrics: Dict, accuracy_metrics: Dict, 
+                  validation_metrics: Dict, error_only_reasoning_metrics: Dict):
+    """Print comprehensive results"""
+    print(f"\n{'='*70}")
+    print(f"Model: {model_name}")
+    print(f"{'='*70}")
+    
+    # 1. ToolCall-Trigger Similarity (tool_call_f1)
+    print(f"\n1. ToolCall-Trigger Similarity (whether tool_calls triggered)")
+    print(f"   Confusion Matrix:")
+    print(f"     TP: {f1_metrics['tp']:3d}  |  FP: {f1_metrics['fp']:3d}")
+    print(f"     FN: {f1_metrics['fn']:3d}  |  TN: {f1_metrics['tn']:3d}")
+    print(f"   Performance Metrics:")
+    print(f"     Precision: {f1_metrics['precision']:.4f} ({f1_metrics['precision']*100:.2f}%)")
+    print(f"     Recall:    {f1_metrics['recall']:.4f} ({f1_metrics['recall']*100:.2f}%)")
+    print(f"     F1 Score:  {f1_metrics['f1']:.4f} ({f1_metrics['f1']*100:.2f}%)")
+    print(f"   Special Cases:")
+    print(f"     Error count: {f1_metrics['error_count']} / {f1_metrics['total_samples']}")
+    if f1_metrics['error_detail']:
+        print(f"     Error details:")
+        for error_type, count in sorted(f1_metrics['error_detail'].items()):
+            print(f"       {error_type}: {count}")
+    
+    # 2. Multi-ToolCall-Trigger Similarity
+    print(f"\n2. Multi-ToolCall-Trigger Similarity (tool_calls count distribution)")
+    print(f"   Cosine Similarity: {multi_metrics['cosine_similarity']:.4f} ({multi_metrics['cosine_similarity']*100:.2f}%)")
+    
+    print(f"\n   Detailed Distribution Comparison:")
+    print(f"   {'Tool Calls':<12} {'Official Count':<15} {'Official Prob':<15} {'Model Count':<12} {'Model Prob':<12} {'Prob Diff':<12}")
+    print(f"   {'-'*78}")
+    for item in multi_metrics['distribution_comparison']:
+        print(f"   {item['tool_calls_count']:<12} "
+              f"{item['official_count']:<10} "
+              f"{item['official_prob']:<12.4f} "
+              f"{item['model_count']:<10} "
+              f"{item['model_prob']:<12.4f} "
+              f"{item['prob_diff']:+12.4f}")
+    
+    # 3. ToolCall-Accuracy (tool call success rate)
+    print(f"\n3. ToolCall-Accuracy (tool call success rate)")
+    print(f"   Success rate: {accuracy_metrics['accuracy']:.4f} ({accuracy_metrics['accuracy']*100:.2f}%)")
+    print(f"   Successful:   {accuracy_metrics['tool_calls_successful_count']}")
+    print(f"   Total:        {accuracy_metrics['tool_calls_finish_tool_calls']}")
+    
+    # 4. Validation Metrics
+    print(f"\n4. Validation Metrics")
+    
+    # Error Repeating
+    error_repeating = validation_metrics['error_repeating']
+    print(f"   Error Repeating:")
+    print(f"     Checked:   {error_repeating['checked_count']}")
+    print(f"     Valid:     {error_repeating['valid_count']}")
+    print(f"     Invalid:   {error_repeating['invalid_count']}")
+    print(f"     Success rate: {error_repeating['success_rate']:.4f} ({error_repeating['success_rate']*100:.2f}%)")
+    
+    # Language Following
+    language_following = validation_metrics['language_following']
+    print(f"   Language Following:")
+    print(f"     Checked:   {language_following['checked_count']}")
+    print(f"     Valid:     {language_following['valid_count']}")
+    print(f"     Invalid:   {language_following['invalid_count']}")
+    print(f"     Success rate: {language_following['success_rate']:.4f} ({language_following['success_rate']*100:.2f}%)")
+    
+    # Overall
+    overall = validation_metrics['overall']
+    print(f"   Overall:")
+    print(f"     Total checked: {overall['total_checked']}")
+    print(f"     Total valid:   {overall['total_valid']}")
+    print(f"     Total invalid: {overall['total_invalid']}")
+    print(f"     Overall success rate: {overall['overall_success_rate']:.4f} ({overall['overall_success_rate']*100:.2f}%)")
+    
+    # 5. Error Only Reasoning (errors containing only reasoning)
+    print(f"\n5. Error Only Reasoning (errors containing only reasoning)")
+    print(f"   Error count:  {error_only_reasoning_metrics['error_only_reasoning_count']}")
+    print(f"   Total checked: {error_only_reasoning_metrics['total_checked']}")
+    print(f"   Error rate:    {error_only_reasoning_metrics['error_only_reasoning_rate']:.4f} ({error_only_reasoning_metrics['error_only_reasoning_rate']*100:.2f}%)")
+
+
+def main(folder_path: str = '/data/minimax-dialogue/users/xiaojun/MiniMax-Vendor-Verifier/batch_results', 
+         reference_model: Optional[str] = None):
+    """
+    Main function: compare tool call similarity of all models in folder
+    
+    Args:
+        folder_path: Folder path containing result files
+        reference_model: Reference model name, if None, use first discovered model as reference
+    """
+    print("="*80)
+    print("Tool Call Similarity Comprehensive Evaluation - Multi-Model Batch Comparison")
+    print("="*80)
+    
+    # Discover all models
+    print(f"\nScanning folder: {folder_path}")
+    models = discover_models(folder_path)
+    
+    if not models:
+        print(f"Error: No model files found in {folder_path}")
+        return
+    
+    model_names = sorted(models.keys())
+    print(f"\nDiscovered {len(model_names)} models: {', '.join(model_names)}")
+    
+    # Determine reference model
+    if reference_model is None:
+        reference_model = model_names[0]
+        print(f"No reference model specified, using first model as reference: {reference_model}")
+    elif reference_model not in models:
+        print(f"Error: Reference model '{reference_model}' does not exist")
+        print(f"Available models: {', '.join(model_names)}")
+        return
+    else:
+        print(f"Using specified reference model: {reference_model}")
+    
+    # Load reference model data
+    print(f"\nLoading reference model data...")
+    ref_results = load_jsonl(models[reference_model]['results'])
+    ref_summary = load_summary(models[reference_model]['summary'])
+    print(f"  Reference model ({reference_model}): {len(ref_results)} samples")
+    
+    # Load all other model data
+    print(f"\nLoading other model data...")
+    all_models_data = {
+        reference_model: {
+            'results': ref_results,
+            'summary': ref_summary
+        }
+    }
+    
+    for model_name in model_names:
+        if model_name != reference_model:
+            results = load_jsonl(models[model_name]['results'])
+            summary = load_summary(models[model_name]['summary'])
+            all_models_data[model_name] = {
+                'results': results,
+                'summary': summary
+            }
+            print(f"  {model_name}: {len(results)} samples")
+    
+    # Calculate similarity between all models and reference model
+    all_metrics = {}
+    
+    for model_name in model_names:
+        if model_name == reference_model:
+            # Reference model compared with itself (perfect match)
+            continue
+        
+        model_results = all_models_data[model_name]['results']
+        model_summary = all_models_data[model_name]['summary']
+        
+        # Calculate ToolCall-Trigger Similarity (F1)
+        f1_metrics = calculate_tool_call_f1(ref_results, model_results)
+        
+        # Calculate Multi-ToolCall-Trigger Similarity (Cosine)
+        multi_metrics = calculate_multi_toolcall_similarity(
+            ref_summary['tool_calls_count_distribution'],
+            model_summary['tool_calls_count_distribution']
+        )
+        
+        # Calculate ToolCall-Accuracy (success rate)
+        accuracy_metrics = calculate_toolcall_accuracy(model_summary)
+        
+        # Calculate Validation Metrics
+        validation_metrics = calculate_validation_metrics(model_summary)
+        
+        # Calculate Error Only Reasoning (errors containing only reasoning)
+        error_only_reasoning_metrics = calculate_error_only_reasoning(model_results)
+        
+        all_metrics[model_name] = {
+            'f1_metrics': f1_metrics,
+            'multi_metrics': multi_metrics,
+            'accuracy_metrics': accuracy_metrics,
+            'validation_metrics': validation_metrics,
+            'error_only_reasoning_metrics': error_only_reasoning_metrics
+        }
+        
+        # Print detailed results for this model
+        print_results(model_name, f1_metrics, multi_metrics, accuracy_metrics, validation_metrics, error_only_reasoning_metrics)
+    
+    # Print comparison summary for all models
+    if len(model_names) > 1:
+        print(f"\n{'='*80}")
+        print(f"All Models Comparison Summary (Reference Model: {reference_model})")
+        print(f"{'='*80}")
+        
+        # Prepare header
+        header = f"{'Metric':<40}"
+        for model_name in model_names:
+            if model_name != reference_model:
+                header += f" {model_name:<15}"
+        print(f"\n{header}")
+        print(f"{'-'*80}")
+        
+        # F1 Score
+        row = f"{'ToolCall-Trigger F1':<40}"
+        for model_name in model_names:
+            if model_name != reference_model:
+                f1 = all_metrics[model_name]['f1_metrics']['f1']
+                row += f" {f1:.4f}         "
+        print(row)
+        
+        # Precision
+        row = f"{'  - Precision':<40}"
+        for model_name in model_names:
+            if model_name != reference_model:
+                precision = all_metrics[model_name]['f1_metrics']['precision']
+                row += f" {precision:.4f}         "
+        print(row)
+        
+        # Recall
+        row = f"{'  - Recall':<40}"
+        for model_name in model_names:
+            if model_name != reference_model:
+                recall = all_metrics[model_name]['f1_metrics']['recall']
+                row += f" {recall:.4f}         "
+        print(row)
+        
+        # Error Count
+        row = f"{'  - Error Count':<40}"
+        for model_name in model_names:
+            if model_name != reference_model:
+                error_count = all_metrics[model_name]['f1_metrics']['error_count']
+                total = all_metrics[model_name]['f1_metrics']['total_samples']
+                row += f" {error_count}/{total}         "
+        print(row)
+        
+        # Cosine Similarity
+        row = f"{'Multi-ToolCall-Trigger Similarity':<40}"
+        for model_name in model_names:
+            if model_name != reference_model:
+                cos_sim = all_metrics[model_name]['multi_metrics']['cosine_similarity']
+                row += f" {cos_sim:.4f}         "
+        print(row)
+        
+        # ToolCall-Accuracy
+        row = f"{'ToolCall-Accuracy':<40}"
+        for model_name in model_names:
+            if model_name != reference_model:
+                accuracy = all_metrics[model_name]['accuracy_metrics']['accuracy']
+                row += f" {accuracy:.4f}         "
+        print(row)
+        
+        # Validation Metrics - Error Repeating Success Rate
+        row = f"{'Error Repeating Success Rate':<40}"
+        for model_name in model_names:
+            if model_name != reference_model:
+                repeat_rate = all_metrics[model_name]['validation_metrics']['error_repeating']['success_rate']
+                row += f" {repeat_rate:.4f}         "
+        print(row)
+        
+        # Validation Metrics - Language Following Success Rate
+        row = f"{'Language Following Success Rate':<40}"
+        for model_name in model_names:
+            if model_name != reference_model:
+                language_rate = all_metrics[model_name]['validation_metrics']['language_following']['success_rate']
+                row += f" {language_rate:.4f}         "
+        print(row)
+        
+        # Validation Metrics - Overall Success Rate
+        row = f"{'Overall Validation Success Rate':<40}"
+        for model_name in model_names:
+            if model_name != reference_model:
+                overall_rate = all_metrics[model_name]['validation_metrics']['overall']['overall_success_rate']
+                row += f" {overall_rate:.4f}         "
+        print(row)
+        
+        # Error Only Reasoning Rate
+        row = f"{'Error Only Reasoning Rate':<40}"
+        for model_name in model_names:
+            if model_name != reference_model:
+                error_reasoning_rate = all_metrics[model_name]['error_only_reasoning_metrics']['error_only_reasoning_rate']
+                row += f" {error_reasoning_rate:.4f}         "
+        print(row)
+    
+    # Save results
+    output = {
+        'reference_model': reference_model,
+        'models': {}
+    }
+    
+    for model_name in model_names:
+        if model_name == reference_model:
+            continue
+            
+        output['models'][model_name] = {
+            'toolcall_trigger_similarity': {
+                'tp': all_metrics[model_name]['f1_metrics']['tp'],
+                'fp': all_metrics[model_name]['f1_metrics']['fp'],
+                'fn': all_metrics[model_name]['f1_metrics']['fn'],
+                'tn': all_metrics[model_name]['f1_metrics']['tn'],
+                'precision': all_metrics[model_name]['f1_metrics']['precision'],
+                'recall': all_metrics[model_name]['f1_metrics']['recall'],
+                'f1': all_metrics[model_name]['f1_metrics']['f1'],
+                'error_count': all_metrics[model_name]['f1_metrics']['error_count'],
+                'error_detail': all_metrics[model_name]['f1_metrics']['error_detail']
+            },
+            'multi_toolcall_trigger_similarity': {
+                'cosine_similarity': all_metrics[model_name]['multi_metrics']['cosine_similarity'],
+                'distribution_comparison': all_metrics[model_name]['multi_metrics']['distribution_comparison']
+            },
+            'toolcall_accuracy': {
+                'accuracy': all_metrics[model_name]['accuracy_metrics']['accuracy'],
+                'tool_calls_successful_count': all_metrics[model_name]['accuracy_metrics']['tool_calls_successful_count'],
+                'tool_calls_finish_tool_calls': all_metrics[model_name]['accuracy_metrics']['tool_calls_finish_tool_calls']
+            },
+            'validation_metrics': {
+                'error_repeating': all_metrics[model_name]['validation_metrics']['error_repeating'],
+                'language_following': all_metrics[model_name]['validation_metrics']['language_following'],
+                'overall': all_metrics[model_name]['validation_metrics']['overall']
+            },
+            'error_only_reasoning': {
+                'error_only_reasoning_count': all_metrics[model_name]['error_only_reasoning_metrics']['error_only_reasoning_count'],
+                'total_checked': all_metrics[model_name]['error_only_reasoning_metrics']['total_checked'],
+                'error_only_reasoning_rate': all_metrics[model_name]['error_only_reasoning_metrics']['error_only_reasoning_rate']
+            }
+        }
+    
+    output['metric_descriptions'] = {
+        'toolcall_trigger_similarity': 'Measures whether the model correctly triggers tool_calls (F1 Score)',
+        'multi_toolcall_trigger_similarity': 'Measures the similarity of count distribution when triggering multiple tool_calls (Cosine Similarity)',
+        'toolcall_accuracy': 'Measures the success rate when triggering tool_calls (successful count / total count)',
+        'validation_metrics': 'Measures the success rate of the model on various validation rules (error_repeating, language_following)',
+        'error_only_reasoning': 'Measures whether the model has errors with only reasoning while content and tool_calls are empty'
+    }
+    
+    output_file = os.path.join(folder_path, 'toolcall_similarity_results.json')
+    with open(output_file, 'w', encoding='utf-8') as f:
+        json.dump(output, f, indent=2, ensure_ascii=False)
+    
+    print(f"\nResults saved to: {output_file}")
+
+
+if __name__ == '__main__':
+    # Default uses batch_results folder
+    # Can modify the following parameters to specify different folder and reference model
+    args = argparse.ArgumentParser()
+    args.add_argument('--folder_path', type=str, default='siliconflow_result')
+    args.add_argument('--reference_model', type=str, default='minimax') # None means use first discovered model as reference, can also specify model name like 'minimax'
+    args = args.parse_args()
+    # Run evaluation
+    main(folder_path=args.folder_path, reference_model=args.reference_model)

--- a/scripts/compare_with_baseline.py
+++ b/scripts/compare_with_baseline.py
@@ -2,10 +2,10 @@
 # -*- coding: utf-8 -*-
 
 """
-与基准数据对比脚本
-使用 MiniMax-M2.5 作为基准，对比验证结果并计算指标
+Baseline Comparison Script
+Compare verification results with MiniMax-M2.5 baseline and calculate metrics
 
-使用方式:
+Usage:
     python3 scripts/compare_with_baseline.py \
         --result-dir output-dir \
         --baseline-dir MiniMax-M2.5 \
@@ -23,7 +23,7 @@ from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 from datetime import datetime
 
-# 添加 scripts 目录到 Python 路径
+# Add scripts directory to Python path
 SCRIPT_DIR = Path(__file__).parent.resolve()
 if str(SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR))
@@ -32,7 +32,7 @@ from calculate_toolcall_similarity import calculate_tool_call_f1
 
 
 def find_summary_files(root_dir: str, provider: str = None) -> List[str]:
-    """递归查找所有 summary.json 文件"""
+    """Recursively find all summary.json files"""
     if provider:
         pattern = os.path.join(root_dir, "**", f"{provider}_summary.json")
     else:
@@ -43,7 +43,7 @@ def find_summary_files(root_dir: str, provider: str = None) -> List[str]:
 
 
 def find_results_files(root_dir: str, provider: str = None) -> List[str]:
-    """递归查找所有 results.jsonl 文件"""
+    """Recursively find all results.jsonl files"""
     if provider:
         pattern = os.path.join(root_dir, "**", f"{provider}_results.jsonl")
     else:
@@ -54,17 +54,17 @@ def find_results_files(root_dir: str, provider: str = None) -> List[str]:
 
 
 def load_json(file_path: str) -> Optional[Dict]:
-    """加载 JSON 文件"""
+    """Load JSON file"""
     try:
         with open(file_path, 'r', encoding='utf-8') as f:
             return json.load(f)
     except Exception as e:
-        print(f"❌ 无法读取文件 {file_path}: {e}")
+        print(f"❌ Cannot read file {file_path}: {e}")
         return None
 
 
 def load_jsonl(file_path: str) -> Optional[List[Dict]]:
-    """加载 JSONL 文件"""
+    """Load JSONL file"""
     try:
         data = []
         with open(file_path, 'r', encoding='utf-8') as f:
@@ -74,12 +74,12 @@ def load_jsonl(file_path: str) -> Optional[List[Dict]]:
                     data.append(json.loads(line))
         return data
     except Exception as e:
-        print(f"❌ 无法读取文件 {file_path}: {e}")
+        print(f"❌ Cannot read file {file_path}: {e}")
         return None
 
 
 def calculate_metrics_from_summary(data: Dict) -> Dict:
-    """根据 summary 数据计算各项指标"""
+    """Calculate metrics from summary data"""
     metrics = {}
     
     all_count = data.get('all_count', 0)
@@ -116,51 +116,51 @@ def calculate_metrics_from_summary(data: Dict) -> Dict:
 
 def match_loops(result_dir: str, baseline_dir: str, provider: str) -> List[Tuple[str, str, str, str]]:
     """
-    匹配结果目录和基准目录的循环
+    Match loops between result directory and baseline directory
     
     Returns:
         List of (result_summary, result_jsonl, baseline_summary, baseline_jsonl)
     """
     matches = []
     
-    # 检查是否是多循环模式
+    # Check if multi-loop mode
     result_loops = sorted(glob.glob(os.path.join(result_dir, "loop_*")))
     baseline_loops = sorted(glob.glob(os.path.join(baseline_dir, "loop_*")))
     
     if result_loops and baseline_loops:
-        # 多循环模式：按循环匹配
-        print(f"📁 多循环模式:")
-        print(f"   结果目录循环数: {len(result_loops)}")
-        print(f"   基准目录循环数: {len(baseline_loops)}")
+        # Multi-loop mode: match by loop
+        print(f"📁 Multi-loop mode:")
+        print(f"   Result directory loops: {len(result_loops)}")
+        print(f"   Baseline directory loops: {len(baseline_loops)}")
         
         for result_loop in result_loops:
             loop_name = os.path.basename(result_loop)
             baseline_loop = os.path.join(baseline_dir, loop_name)
             
             if not os.path.exists(baseline_loop):
-                print(f"   ⚠️  {loop_name}: 基准目录无匹配")
+                print(f"   ⚠️  {loop_name}: No match in baseline directory")
                 continue
             
-            # 查找该循环的文件
+            # Find files for this loop
             result_summary = find_summary_files(result_loop, provider)
-            # 优先查找 minimax_summary.json，如果找不到则查找任意 *_summary.json
+            # Prefer minimax_summary.json, fallback to any *_summary.json
             baseline_summary = find_summary_files(baseline_loop, "minimax")
             if not baseline_summary:
-                baseline_summary = find_summary_files(baseline_loop, None)  # 查找任意 summary 文件
+                baseline_summary = find_summary_files(baseline_loop, None)  # Find any summary file
             
             if not result_summary:
-                print(f"   ⚠️  {loop_name}: 结果目录无 summary 文件")
+                print(f"   ⚠️  {loop_name}: No summary file in result directory")
                 continue
             if not baseline_summary:
-                print(f"   ⚠️  {loop_name}: 基准目录无 summary 文件")
+                print(f"   ⚠️  {loop_name}: No summary file in baseline directory")
                 continue
             
-            # 查找 results.jsonl
+            # Find results.jsonl
             result_jsonl_path = result_summary[0].replace('_summary.json', '_results.jsonl')
-            # 优先查找 minimax_results.jsonl，如果找不到则查找任意 *_results.jsonl
+            # Prefer minimax_results.jsonl, fallback to any *_results.jsonl
             baseline_jsonl = find_results_files(baseline_loop, "minimax")
             if not baseline_jsonl:
-                baseline_jsonl = find_results_files(baseline_loop, None)  # 查找任意 results 文件
+                baseline_jsonl = find_results_files(baseline_loop, None)  # Find any results file
             
             if not os.path.exists(result_jsonl_path):
                 result_jsonl_path = None
@@ -173,17 +173,17 @@ def match_loops(result_dir: str, baseline_dir: str, provider: str) -> List[Tuple
                 baseline_summary[0],
                 baseline_jsonl_path
             ))
-            print(f"   ✅ {loop_name}: 匹配成功")
+            print(f"   ✅ {loop_name}: Match successful")
     
     else:
-        # 单次运行模式：直接匹配
-        print(f"📁 单次运行模式")
+        # Single run mode: direct match
+        print(f"📁 Single run mode")
         
         result_summary = find_summary_files(result_dir, provider)
-        # 优先查找 minimax_summary.json，如果找不到则查找任意 *_summary.json
+        # Prefer minimax_summary.json, fallback to any *_summary.json
         baseline_summary = find_summary_files(baseline_dir, "minimax")
         if not baseline_summary:
-            baseline_summary = find_summary_files(baseline_dir, None)  # 查找任意 summary 文件
+            baseline_summary = find_summary_files(baseline_dir, None)  # Find any summary file
         
         if result_summary and baseline_summary:
             result_jsonl_path = result_summary[0].replace('_summary.json', '_results.jsonl')
@@ -200,7 +200,7 @@ def match_loops(result_dir: str, baseline_dir: str, provider: str) -> List[Tuple
                 baseline_summary[0],
                 baseline_jsonl_path
             ))
-            print(f"   ✅ 匹配成功")
+            print(f"   ✅ Match successful")
     
     return matches
 
@@ -211,13 +211,13 @@ def compare_single_loop(
     baseline_summary_path: str,
     baseline_jsonl_path: Optional[str]
 ) -> Dict:
-    """对比单个循环的结果"""
+    """Compare results for a single loop"""
     result = {
         'result_file': result_summary_path,
         'baseline_file': baseline_summary_path,
     }
     
-    # 加载 summary 数据
+    # Load summary data
     result_summary = load_json(result_summary_path)
     baseline_summary = load_json(baseline_summary_path)
     
@@ -229,21 +229,21 @@ def compare_single_loop(
     result['model'] = result_summary.get('model', 'Unknown')
     result['baseline_model'] = baseline_summary.get('model', 'Unknown')
     
-    # 计算基础指标
+    # Calculate base metrics
     result['metrics'] = calculate_metrics_from_summary(result_summary)
     result['baseline_metrics'] = calculate_metrics_from_summary(baseline_summary)
     
-    # 计算 ToolCalls-Trigger-Similarity（如果有 results.jsonl）
+    # Calculate ToolCalls-Trigger-Similarity (if results.jsonl exists)
     if result_jsonl_path and baseline_jsonl_path:
         result_data = load_jsonl(result_jsonl_path)
         baseline_data = load_jsonl(baseline_jsonl_path)
         
         if result_data and baseline_data:
             try:
-                # 样本数对齐
+                # Align sample count
                 min_len = min(len(result_data), len(baseline_data))
                 if len(result_data) != len(baseline_data):
-                    print(f"   ⚠️  样本数不匹配 (result: {len(result_data)}, baseline: {len(baseline_data)})，使用前 {min_len} 个")
+                    print(f"   ⚠️  Sample count mismatch (result: {len(result_data)}, baseline: {len(baseline_data)}), using first {min_len}")
                 
                 f1_metrics = calculate_tool_call_f1(baseline_data[:min_len], result_data[:min_len])
                 result['toolcalls_trigger_similarity'] = {
@@ -258,23 +258,23 @@ def compare_single_loop(
                 }
                 result['metrics']['ToolCalls-Trigger-Similarity-F1'] = f1_metrics['f1']
             except Exception as e:
-                print(f"   ⚠️  计算 ToolCalls-Trigger-Similarity 失败: {e}")
+                print(f"   ⚠️  Failed to calculate ToolCalls-Trigger-Similarity: {e}")
                 result['metrics']['ToolCalls-Trigger-Similarity-F1'] = None
         else:
             result['metrics']['ToolCalls-Trigger-Similarity-F1'] = None
     else:
         result['metrics']['ToolCalls-Trigger-Similarity-F1'] = None
         if not result_jsonl_path:
-            print(f"   ⚠️  结果目录无 results.jsonl，无法计算 ToolCalls-Trigger-Similarity")
+            print(f"   ⚠️  No results.jsonl in result directory, cannot calculate ToolCalls-Trigger-Similarity")
         if not baseline_jsonl_path:
-            print(f"   ⚠️  基准目录无 minimax_results.jsonl，无法计算 ToolCalls-Trigger-Similarity")
+            print(f"   ⚠️  No minimax_results.jsonl in baseline directory, cannot calculate ToolCalls-Trigger-Similarity")
     
     result['status'] = 'success'
     return result
 
 
 def calculate_average_metrics(all_results: List[Dict]) -> Dict:
-    """计算所有循环的平均指标"""
+    """Calculate average metrics across all loops"""
     successful_results = [r for r in all_results if r.get('status') == 'success']
     
     if not successful_results:
@@ -330,25 +330,25 @@ def calculate_average_metrics(all_results: List[Dict]) -> Dict:
 
 
 def print_comparison_table(all_results: List[Dict], avg_metrics: Dict):
-    """打印对比结果表格"""
+    """Print comparison results table"""
     print("\n" + "=" * 120)
-    print("📊 对比结果汇总")
+    print("📊 Comparison Results Summary")
     print("=" * 120)
     
     successful_results = [r for r in all_results if r.get('status') == 'success']
     
     if not successful_results:
-        print("❌ 没有成功的对比结果")
+        print("❌ No successful comparison results")
         return
     
     has_similarity = any(r['metrics'].get('ToolCalls-Trigger-Similarity-F1') is not None for r in successful_results)
     
-    # 表头
+    # Header
     if has_similarity:
-        print(f"\n{'循环':<15} {'模型':<25} {'Q-Succ':<10} {'F-Tool':<10} {'TC-Sim-F1':<12} {'Tool-Acc':<10} {'R-Succ':<10} {'Lang-Succ':<10}")
+        print(f"\n{'Loop':<15} {'Model':<25} {'Q-Succ':<10} {'F-Tool':<10} {'TC-Sim-F1':<12} {'Tool-Acc':<10} {'R-Succ':<10} {'Lang-Succ':<10}")
         print("-" * 120)
     else:
-        print(f"\n{'循环':<15} {'模型':<25} {'Q-Succ':<10} {'F-Tool':<10} {'Tool-Acc':<10} {'R-Succ':<10} {'Lang-Succ':<10}")
+        print(f"\n{'Loop':<15} {'Model':<25} {'Q-Succ':<10} {'F-Tool':<10} {'Tool-Acc':<10} {'R-Succ':<10} {'Lang-Succ':<10}")
         print("-" * 100)
     
     for i, result in enumerate(successful_results, 1):
@@ -379,9 +379,9 @@ def print_comparison_table(all_results: List[Dict], avg_metrics: Dict):
     
     print("=" * (120 if has_similarity else 100))
     
-    # 打印平均值
+    # Print averages
     if avg_metrics:
-        print(f"\n📈 平均指标 (共 {len(successful_results)} 次对比):")
+        print(f"\n📈 Average Metrics ({len(successful_results)} comparisons):")
         print(f"  1. Query-Success-Rate: {avg_metrics.get('Query-Success-Rate', 0):.4f} ({avg_metrics.get('Query-Success-Rate', 0)*100:.2f}%)")
         print(f"  2. Finish-ToolCalls-Rate: {avg_metrics.get('Finish-ToolCalls-Rate', 0):.4f} ({avg_metrics.get('Finish-ToolCalls-Rate', 0)*100:.2f}%)")
         if 'ToolCalls-Trigger-Similarity-F1' in avg_metrics:
@@ -392,7 +392,7 @@ def print_comparison_table(all_results: List[Dict], avg_metrics: Dict):
         
         # Token Usage
         if 'Token-Usage' in avg_metrics:
-            print(f"\n  Token 使用统计平均值:")
+            print(f"\n  Token Usage Statistics Averages:")
             tu = avg_metrics['Token-Usage']
             if 'prompt_tokens' in tu:
                 print(f"    - Avg Prompt Tokens: {tu['prompt_tokens']['average']:.2f}")
@@ -405,7 +405,7 @@ def print_comparison_table(all_results: List[Dict], avg_metrics: Dict):
 
 
 def send_report(summary: Dict, api_url: Optional[str] = None) -> bool:
-    """发送报告到 API"""
+    """Send report to API"""
     import requests
     
     if not api_url:
@@ -414,27 +414,27 @@ def send_report(summary: Dict, api_url: Optional[str] = None) -> bool:
             'https://swing.xaminim.com/minimax/provider/report/send'
         )
     
-    print(f"\n📧 发送报告到: {api_url}")
+    print(f"\n📧 Sending report to: {api_url}")
     
     try:
-        # 从环境变量获取配置
+        # Get config from environment variable
         provider_config_str = os.environ.get('PROVIDER_VERIFIER_CONFIG', '')
         provider_config = {}
         if provider_config_str:
             try:
                 provider_config = json.loads(provider_config_str)
-                print(f"  📦 已加载 PROVIDER_VERIFIER_CONFIG")
+                print(f"  📦 Loaded PROVIDER_VERIFIER_CONFIG")
             except json.JSONDecodeError:
                 pass
         
-        # 构建请求数据（与 send_metrics_report.py 保持一致）
+        # Build request data (consistent with send_metrics_report.py)
         payload = {
             'average_metrics': summary.get('average_metrics', {}),
             **provider_config
         }
         
-        # 注意：这里的 key 是 average_metrics，与 send_metrics_report.py 的 aggregated_metrics 对应
-        # 两者内容结构相同，都是平均指标
+        # Note: key is average_metrics, corresponds to aggregated_metrics in send_metrics_report.py
+        # Both have the same content structure - average metrics
         
         print("\n📤 Request Body:")
         print("-" * 60)
@@ -449,84 +449,84 @@ def send_report(summary: Dict, api_url: Optional[str] = None) -> bool:
         )
         
         if response.status_code == 200:
-            print("\n✅ 报告发送成功")
+            print("\n✅ Report sent successfully")
             try:
                 result = response.json()
-                print(f"  响应: {result}")
+                print(f"  Response: {result}")
             except:
                 pass
             return True
         else:
-            print(f"\n❌ 报告发送失败: HTTP {response.status_code}")
-            print(f"  响应: {response.text}")
+            print(f"\n❌ Failed to send report: HTTP {response.status_code}")
+            print(f"  Response: {response.text}")
             return False
     
     except Exception as e:
-        print(f"❌ 发送报告失败: {e}")
+        print(f"❌ Failed to send report: {e}")
         return False
 
 
 def main():
     parser = argparse.ArgumentParser(
-        description='与基准数据对比并计算指标'
+        description='Compare with baseline data and calculate metrics'
     )
     
     parser.add_argument(
         '--result-dir',
         type=str,
         required=True,
-        help='验证结果目录'
+        help='Verification result directory'
     )
     
     parser.add_argument(
         '--baseline-dir',
         type=str,
         default='MiniMax-M2.5',
-        help='基准数据目录 (默认: MiniMax-M2.5)'
+        help='Baseline data directory (default: MiniMax-M2.5)'
     )
     
     parser.add_argument(
         '--provider',
         type=str,
         default=None,
-        help='Provider 名称（自动检测）'
+        help='Provider name (auto-detected)'
     )
     
     parser.add_argument(
         '--output',
         type=str,
         default=None,
-        help='输出报告文件路径'
+        help='Output report file path'
     )
     
     parser.add_argument(
         '--send-report',
         action='store_true',
-        help='发送报告到 API'
+        help='Send report to API'
     )
     
     parser.add_argument(
         '--api-url',
         type=str,
         default=None,
-        help='报告 API URL'
+        help='Report API URL'
     )
     
     args = parser.parse_args()
     
     print("=" * 60)
-    print("📊 MiniMax Provider Verifier - 基准对比")
+    print("📊 MiniMax Provider Verifier - Baseline Comparison")
     print("=" * 60)
     
-    # 检查目录
+    # Check directories
     if not os.path.exists(args.result_dir):
-        print(f"❌ 结果目录不存在: {args.result_dir}")
+        print(f"❌ Result directory does not exist: {args.result_dir}")
         return 1
     
-    # 解析基准目录（支持相对路径）
+    # Parse baseline directory (supports relative paths)
     baseline_dir = args.baseline_dir
     if not os.path.isabs(baseline_dir):
-        # 尝试多个可能的位置
+        # Try multiple possible locations
         possible_paths = [
             baseline_dir,
             os.path.join(os.path.dirname(args.result_dir), baseline_dir),
@@ -538,44 +538,44 @@ def main():
                 break
     
     if not os.path.exists(baseline_dir):
-        print(f"❌ 基准目录不存在: {baseline_dir}")
+        print(f"❌ Baseline directory does not exist: {baseline_dir}")
         return 1
     
-    print(f"📂 结果目录: {args.result_dir}")
-    print(f"📂 基准目录: {baseline_dir}")
+    print(f"📂 Result directory: {args.result_dir}")
+    print(f"📂 Baseline directory: {baseline_dir}")
     
-    # 自动检测 provider
+    # Auto-detect provider
     provider = args.provider
     if not provider:
         summary_files = find_summary_files(args.result_dir)
         if summary_files:
-            # 从文件名提取 provider
+            # Extract provider from filename
             basename = os.path.basename(summary_files[0])
             provider = basename.replace('_summary.json', '')
-            print(f"📦 自动检测 provider: {provider}")
+            print(f"📦 Auto-detected provider: {provider}")
     
     if not provider:
-        print("❌ 无法自动检测 provider，请使用 --provider 参数指定")
+        print("❌ Cannot auto-detect provider, please use --provider argument")
         return 1
     
-    # 匹配循环
-    print("\n🔍 匹配结果与基准...")
+    # Match loops
+    print("\n🔍 Matching results with baseline...")
     matches = match_loops(args.result_dir, baseline_dir, provider)
     
     if not matches:
-        print("❌ 没有找到可匹配的数据")
+        print("❌ No matching data found")
         return 1
     
-    print(f"\n✅ 找到 {len(matches)} 组匹配")
+    print(f"\n✅ Found {len(matches)} matches")
     
-    # 执行对比
-    print("\n🔄 开始对比...")
+    # Execute comparison
+    print("\n🔄 Starting comparison...")
     all_results = []
     
     for i, (result_summary, result_jsonl, baseline_summary, baseline_jsonl) in enumerate(matches, 1):
-        print(f"\n--- 对比 {i}/{len(matches)} ---")
-        print(f"   结果: {result_summary}")
-        print(f"   基准: {baseline_summary}")
+        print(f"\n--- Comparison {i}/{len(matches)} ---")
+        print(f"   Result: {result_summary}")
+        print(f"   Baseline: {baseline_summary}")
         
         result = compare_single_loop(
             result_summary, result_jsonl,
@@ -583,13 +583,13 @@ def main():
         )
         all_results.append(result)
     
-    # 计算平均指标
+    # Calculate average metrics
     avg_metrics = calculate_average_metrics(all_results)
     
-    # 打印结果
+    # Print results
     print_comparison_table(all_results, avg_metrics)
     
-    # 构建最终报告
+    # Build final report
     report = {
         'provider': provider,
         'baseline_dir': baseline_dir,
@@ -601,21 +601,21 @@ def main():
         'comparisons': all_results
     }
     
-    # 保存报告
+    # Save report
     output_file = args.output
     if not output_file:
         output_file = os.path.join(args.result_dir, 'comparison_report.json')
     
-    print(f"\n💾 保存报告到: {output_file}")
+    print(f"\n💾 Saving report to: {output_file}")
     with open(output_file, 'w', encoding='utf-8') as f:
         json.dump(report, f, indent=2, ensure_ascii=False)
-    print("✅ 报告保存成功")
+    print("✅ Report saved successfully")
     
-    # 发送报告
+    # Send report
     if args.send_report:
         send_report(report, args.api_url)
     
-    print("\n🎉 对比完成！")
+    print("\n🎉 Comparison completed!")
     return 0
 
 

--- a/scripts/compare_with_baseline.py
+++ b/scripts/compare_with_baseline.py
@@ -1,0 +1,623 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+与基准数据对比脚本
+使用 MiniMax-M2.5 作为基准，对比验证结果并计算指标
+
+使用方式:
+    python3 scripts/compare_with_baseline.py \
+        --result-dir output-dir \
+        --baseline-dir MiniMax-M2.5 \
+        --provider minimax \
+        --output output-dir/comparison_report.json \
+        --send-report
+"""
+
+import os
+import sys
+import json
+import glob
+import argparse
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+from datetime import datetime
+
+# 添加 scripts 目录到 Python 路径
+SCRIPT_DIR = Path(__file__).parent.resolve()
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from calculate_toolcall_similarity import calculate_tool_call_f1
+
+
+def find_summary_files(root_dir: str, provider: str = None) -> List[str]:
+    """递归查找所有 summary.json 文件"""
+    if provider:
+        pattern = os.path.join(root_dir, "**", f"{provider}_summary.json")
+    else:
+        pattern = os.path.join(root_dir, "**", "*_summary.json")
+    
+    files = glob.glob(pattern, recursive=True)
+    return sorted(files)
+
+
+def find_results_files(root_dir: str, provider: str = None) -> List[str]:
+    """递归查找所有 results.jsonl 文件"""
+    if provider:
+        pattern = os.path.join(root_dir, "**", f"{provider}_results.jsonl")
+    else:
+        pattern = os.path.join(root_dir, "**", "*_results.jsonl")
+    
+    files = glob.glob(pattern, recursive=True)
+    return sorted(files)
+
+
+def load_json(file_path: str) -> Optional[Dict]:
+    """加载 JSON 文件"""
+    try:
+        with open(file_path, 'r', encoding='utf-8') as f:
+            return json.load(f)
+    except Exception as e:
+        print(f"❌ 无法读取文件 {file_path}: {e}")
+        return None
+
+
+def load_jsonl(file_path: str) -> Optional[List[Dict]]:
+    """加载 JSONL 文件"""
+    try:
+        data = []
+        with open(file_path, 'r', encoding='utf-8') as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    data.append(json.loads(line))
+        return data
+    except Exception as e:
+        print(f"❌ 无法读取文件 {file_path}: {e}")
+        return None
+
+
+def calculate_metrics_from_summary(data: Dict) -> Dict:
+    """根据 summary 数据计算各项指标"""
+    metrics = {}
+    
+    all_count = data.get('all_count', 0)
+    success_count = data.get('success_count', 0)
+    metrics['Query-Success-Rate'] = success_count / all_count if all_count > 0 else 0
+    
+    finish_tool_calls_count = data.get('tool_calls_finish_tool_calls', 0)
+    metrics['Finish-ToolCalls-Rate'] = finish_tool_calls_count / all_count if all_count > 0 else 0
+    
+    tool_calls_successful_count = data.get('tool_calls_successful_count', 0)
+    metrics['ToolCalls-Accuracy'] = tool_calls_successful_count / finish_tool_calls_count if finish_tool_calls_count > 0 else 0
+    
+    error_only_reasoning_count = data.get('error_only_reasoning_count', 0)
+    error_only_reasoning_checked_count = data.get('error_only_reasoning_checked_count', 0)
+    metrics['Response-Success-Rate-Not-Only-Reasoning'] = (
+        (error_only_reasoning_checked_count - error_only_reasoning_count) / error_only_reasoning_checked_count 
+        if error_only_reasoning_checked_count > 0 else 0
+    )
+    
+    language_following_valid_count = data.get('language_following_valid_count', 0)
+    language_following_checked_count = data.get('language_following_checked_count', 0)
+    metrics['Language-Following-Success-Rate'] = (
+        language_following_valid_count / language_following_checked_count 
+        if language_following_checked_count > 0 else 0
+    )
+    
+    # Token Usage
+    token_usage = data.get('token_usage', {})
+    if token_usage:
+        metrics['token_usage'] = token_usage
+    
+    return metrics
+
+
+def match_loops(result_dir: str, baseline_dir: str, provider: str) -> List[Tuple[str, str, str, str]]:
+    """
+    匹配结果目录和基准目录的循环
+    
+    Returns:
+        List of (result_summary, result_jsonl, baseline_summary, baseline_jsonl)
+    """
+    matches = []
+    
+    # 检查是否是多循环模式
+    result_loops = sorted(glob.glob(os.path.join(result_dir, "loop_*")))
+    baseline_loops = sorted(glob.glob(os.path.join(baseline_dir, "loop_*")))
+    
+    if result_loops and baseline_loops:
+        # 多循环模式：按循环匹配
+        print(f"📁 多循环模式:")
+        print(f"   结果目录循环数: {len(result_loops)}")
+        print(f"   基准目录循环数: {len(baseline_loops)}")
+        
+        for result_loop in result_loops:
+            loop_name = os.path.basename(result_loop)
+            baseline_loop = os.path.join(baseline_dir, loop_name)
+            
+            if not os.path.exists(baseline_loop):
+                print(f"   ⚠️  {loop_name}: 基准目录无匹配")
+                continue
+            
+            # 查找该循环的文件
+            result_summary = find_summary_files(result_loop, provider)
+            # 优先查找 minimax_summary.json，如果找不到则查找任意 *_summary.json
+            baseline_summary = find_summary_files(baseline_loop, "minimax")
+            if not baseline_summary:
+                baseline_summary = find_summary_files(baseline_loop, None)  # 查找任意 summary 文件
+            
+            if not result_summary:
+                print(f"   ⚠️  {loop_name}: 结果目录无 summary 文件")
+                continue
+            if not baseline_summary:
+                print(f"   ⚠️  {loop_name}: 基准目录无 summary 文件")
+                continue
+            
+            # 查找 results.jsonl
+            result_jsonl_path = result_summary[0].replace('_summary.json', '_results.jsonl')
+            # 优先查找 minimax_results.jsonl，如果找不到则查找任意 *_results.jsonl
+            baseline_jsonl = find_results_files(baseline_loop, "minimax")
+            if not baseline_jsonl:
+                baseline_jsonl = find_results_files(baseline_loop, None)  # 查找任意 results 文件
+            
+            if not os.path.exists(result_jsonl_path):
+                result_jsonl_path = None
+            
+            baseline_jsonl_path = baseline_jsonl[0] if baseline_jsonl else None
+            
+            matches.append((
+                result_summary[0],
+                result_jsonl_path,
+                baseline_summary[0],
+                baseline_jsonl_path
+            ))
+            print(f"   ✅ {loop_name}: 匹配成功")
+    
+    else:
+        # 单次运行模式：直接匹配
+        print(f"📁 单次运行模式")
+        
+        result_summary = find_summary_files(result_dir, provider)
+        # 优先查找 minimax_summary.json，如果找不到则查找任意 *_summary.json
+        baseline_summary = find_summary_files(baseline_dir, "minimax")
+        if not baseline_summary:
+            baseline_summary = find_summary_files(baseline_dir, None)  # 查找任意 summary 文件
+        
+        if result_summary and baseline_summary:
+            result_jsonl_path = result_summary[0].replace('_summary.json', '_results.jsonl')
+            baseline_jsonl = find_results_files(baseline_dir, "minimax")
+            
+            if not os.path.exists(result_jsonl_path):
+                result_jsonl_path = None
+            
+            baseline_jsonl_path = baseline_jsonl[0] if baseline_jsonl else None
+            
+            matches.append((
+                result_summary[0],
+                result_jsonl_path,
+                baseline_summary[0],
+                baseline_jsonl_path
+            ))
+            print(f"   ✅ 匹配成功")
+    
+    return matches
+
+
+def compare_single_loop(
+    result_summary_path: str,
+    result_jsonl_path: Optional[str],
+    baseline_summary_path: str,
+    baseline_jsonl_path: Optional[str]
+) -> Dict:
+    """对比单个循环的结果"""
+    result = {
+        'result_file': result_summary_path,
+        'baseline_file': baseline_summary_path,
+    }
+    
+    # 加载 summary 数据
+    result_summary = load_json(result_summary_path)
+    baseline_summary = load_json(baseline_summary_path)
+    
+    if not result_summary or not baseline_summary:
+        result['status'] = 'error'
+        result['error'] = 'Failed to load summary files'
+        return result
+    
+    result['model'] = result_summary.get('model', 'Unknown')
+    result['baseline_model'] = baseline_summary.get('model', 'Unknown')
+    
+    # 计算基础指标
+    result['metrics'] = calculate_metrics_from_summary(result_summary)
+    result['baseline_metrics'] = calculate_metrics_from_summary(baseline_summary)
+    
+    # 计算 ToolCalls-Trigger-Similarity（如果有 results.jsonl）
+    if result_jsonl_path and baseline_jsonl_path:
+        result_data = load_jsonl(result_jsonl_path)
+        baseline_data = load_jsonl(baseline_jsonl_path)
+        
+        if result_data and baseline_data:
+            try:
+                # 样本数对齐
+                min_len = min(len(result_data), len(baseline_data))
+                if len(result_data) != len(baseline_data):
+                    print(f"   ⚠️  样本数不匹配 (result: {len(result_data)}, baseline: {len(baseline_data)})，使用前 {min_len} 个")
+                
+                f1_metrics = calculate_tool_call_f1(baseline_data[:min_len], result_data[:min_len])
+                result['toolcalls_trigger_similarity'] = {
+                    'f1': f1_metrics['f1'],
+                    'precision': f1_metrics['precision'],
+                    'recall': f1_metrics['recall'],
+                    'tp': f1_metrics['tp'],
+                    'fp': f1_metrics['fp'],
+                    'fn': f1_metrics['fn'],
+                    'tn': f1_metrics['tn'],
+                    'samples_used': min_len
+                }
+                result['metrics']['ToolCalls-Trigger-Similarity-F1'] = f1_metrics['f1']
+            except Exception as e:
+                print(f"   ⚠️  计算 ToolCalls-Trigger-Similarity 失败: {e}")
+                result['metrics']['ToolCalls-Trigger-Similarity-F1'] = None
+        else:
+            result['metrics']['ToolCalls-Trigger-Similarity-F1'] = None
+    else:
+        result['metrics']['ToolCalls-Trigger-Similarity-F1'] = None
+        if not result_jsonl_path:
+            print(f"   ⚠️  结果目录无 results.jsonl，无法计算 ToolCalls-Trigger-Similarity")
+        if not baseline_jsonl_path:
+            print(f"   ⚠️  基准目录无 minimax_results.jsonl，无法计算 ToolCalls-Trigger-Similarity")
+    
+    result['status'] = 'success'
+    return result
+
+
+def calculate_average_metrics(all_results: List[Dict]) -> Dict:
+    """计算所有循环的平均指标"""
+    successful_results = [r for r in all_results if r.get('status') == 'success']
+    
+    if not successful_results:
+        return {}
+    
+    metric_keys = [
+        'Query-Success-Rate',
+        'Finish-ToolCalls-Rate',
+        'ToolCalls-Trigger-Similarity-F1',
+        'ToolCalls-Accuracy',
+        'Response-Success-Rate-Not-Only-Reasoning',
+        'Language-Following-Success-Rate'
+    ]
+    
+    avg_metrics = {}
+    for key in metric_keys:
+        values = []
+        for r in successful_results:
+            val = r['metrics'].get(key)
+            if val is not None:
+                values.append(val)
+        if values:
+            avg_metrics[key] = sum(values) / len(values)
+    
+    # Token Usage 平均
+    token_usage_list = []
+    for r in successful_results:
+        if 'token_usage' in r['metrics']:
+            token_usage_list.append(r['metrics']['token_usage'])
+    
+    if token_usage_list:
+        avg_token_usage = {}
+        token_types = ['prompt_tokens', 'completion_tokens', 'total_tokens', 'reasoning_tokens', 'cached_tokens']
+        
+        for token_type in token_types:
+            averages = []
+            totals = []
+            for tu in token_usage_list:
+                if token_type in tu and isinstance(tu[token_type], dict):
+                    averages.append(tu[token_type].get('average', 0))
+                    totals.append(tu[token_type].get('total', 0))
+            
+            if averages:
+                avg_token_usage[token_type] = {
+                    'average': sum(averages) / len(averages),
+                    'total': sum(totals)
+                }
+        
+        if avg_token_usage:
+            avg_metrics['Token-Usage'] = avg_token_usage
+    
+    return avg_metrics
+
+
+def print_comparison_table(all_results: List[Dict], avg_metrics: Dict):
+    """打印对比结果表格"""
+    print("\n" + "=" * 120)
+    print("📊 对比结果汇总")
+    print("=" * 120)
+    
+    successful_results = [r for r in all_results if r.get('status') == 'success']
+    
+    if not successful_results:
+        print("❌ 没有成功的对比结果")
+        return
+    
+    has_similarity = any(r['metrics'].get('ToolCalls-Trigger-Similarity-F1') is not None for r in successful_results)
+    
+    # 表头
+    if has_similarity:
+        print(f"\n{'循环':<15} {'模型':<25} {'Q-Succ':<10} {'F-Tool':<10} {'TC-Sim-F1':<12} {'Tool-Acc':<10} {'R-Succ':<10} {'Lang-Succ':<10}")
+        print("-" * 120)
+    else:
+        print(f"\n{'循环':<15} {'模型':<25} {'Q-Succ':<10} {'F-Tool':<10} {'Tool-Acc':<10} {'R-Succ':<10} {'Lang-Succ':<10}")
+        print("-" * 100)
+    
+    for i, result in enumerate(successful_results, 1):
+        loop_name = f"Loop {i}"
+        model = result.get('model', 'Unknown')
+        if len(model) > 23:
+            model = model[:20] + "..."
+        
+        metrics = result['metrics']
+        
+        if has_similarity:
+            sim_f1 = metrics.get('ToolCalls-Trigger-Similarity-F1')
+            sim_str = f"{sim_f1*100:>10.2f}%" if sim_f1 is not None else "N/A".rjust(12)
+            print(f"{loop_name:<15} {model:<25} "
+                  f"{metrics.get('Query-Success-Rate', 0)*100:>8.2f}% "
+                  f"{metrics.get('Finish-ToolCalls-Rate', 0)*100:>8.2f}% "
+                  f"{sim_str} "
+                  f"{metrics.get('ToolCalls-Accuracy', 0)*100:>8.2f}% "
+                  f"{metrics.get('Response-Success-Rate-Not-Only-Reasoning', 0)*100:>8.2f}% "
+                  f"{metrics.get('Language-Following-Success-Rate', 0)*100:>8.2f}%")
+        else:
+            print(f"{loop_name:<15} {model:<25} "
+                  f"{metrics.get('Query-Success-Rate', 0)*100:>8.2f}% "
+                  f"{metrics.get('Finish-ToolCalls-Rate', 0)*100:>8.2f}% "
+                  f"{metrics.get('ToolCalls-Accuracy', 0)*100:>8.2f}% "
+                  f"{metrics.get('Response-Success-Rate-Not-Only-Reasoning', 0)*100:>8.2f}% "
+                  f"{metrics.get('Language-Following-Success-Rate', 0)*100:>8.2f}%")
+    
+    print("=" * (120 if has_similarity else 100))
+    
+    # 打印平均值
+    if avg_metrics:
+        print(f"\n📈 平均指标 (共 {len(successful_results)} 次对比):")
+        print(f"  1. Query-Success-Rate: {avg_metrics.get('Query-Success-Rate', 0):.4f} ({avg_metrics.get('Query-Success-Rate', 0)*100:.2f}%)")
+        print(f"  2. Finish-ToolCalls-Rate: {avg_metrics.get('Finish-ToolCalls-Rate', 0):.4f} ({avg_metrics.get('Finish-ToolCalls-Rate', 0)*100:.2f}%)")
+        if 'ToolCalls-Trigger-Similarity-F1' in avg_metrics:
+            print(f"  3. ToolCalls-Trigger-Similarity-F1: {avg_metrics['ToolCalls-Trigger-Similarity-F1']:.4f} ({avg_metrics['ToolCalls-Trigger-Similarity-F1']*100:.2f}%)")
+        print(f"  4. ToolCalls-Accuracy: {avg_metrics.get('ToolCalls-Accuracy', 0):.4f} ({avg_metrics.get('ToolCalls-Accuracy', 0)*100:.2f}%)")
+        print(f"  5. Response-Success-Rate-Not-Only-Reasoning: {avg_metrics.get('Response-Success-Rate-Not-Only-Reasoning', 0):.4f} ({avg_metrics.get('Response-Success-Rate-Not-Only-Reasoning', 0)*100:.2f}%)")
+        print(f"  6. Language-Following-Success-Rate: {avg_metrics.get('Language-Following-Success-Rate', 0):.4f} ({avg_metrics.get('Language-Following-Success-Rate', 0)*100:.2f}%)")
+        
+        # Token Usage
+        if 'Token-Usage' in avg_metrics:
+            print(f"\n  Token 使用统计平均值:")
+            tu = avg_metrics['Token-Usage']
+            if 'prompt_tokens' in tu:
+                print(f"    - Avg Prompt Tokens: {tu['prompt_tokens']['average']:.2f}")
+            if 'completion_tokens' in tu:
+                print(f"    - Avg Completion Tokens: {tu['completion_tokens']['average']:.2f}")
+            if 'reasoning_tokens' in tu:
+                print(f"    - Avg Reasoning Tokens: {tu['reasoning_tokens']['average']:.2f}")
+            if 'total_tokens' in tu:
+                print(f"    - Avg Total Tokens: {tu['total_tokens']['average']:.2f}")
+
+
+def send_report(summary: Dict, api_url: Optional[str] = None) -> bool:
+    """发送报告到 API"""
+    import requests
+    
+    if not api_url:
+        api_url = os.environ.get(
+            'METRICS_REPORT_API_URL',
+            'https://swing.xaminim.com/minimax/provider/report/send'
+        )
+    
+    print(f"\n📧 发送报告到: {api_url}")
+    
+    try:
+        # 从环境变量获取配置
+        provider_config_str = os.environ.get('PROVIDER_VERIFIER_CONFIG', '')
+        provider_config = {}
+        if provider_config_str:
+            try:
+                provider_config = json.loads(provider_config_str)
+                print(f"  📦 已加载 PROVIDER_VERIFIER_CONFIG")
+            except json.JSONDecodeError:
+                pass
+        
+        # 构建请求数据（与 send_metrics_report.py 保持一致）
+        payload = {
+            'average_metrics': summary.get('average_metrics', {}),
+            **provider_config
+        }
+        
+        # 注意：这里的 key 是 average_metrics，与 send_metrics_report.py 的 aggregated_metrics 对应
+        # 两者内容结构相同，都是平均指标
+        
+        print("\n📤 Request Body:")
+        print("-" * 60)
+        print(json.dumps(payload, indent=2, ensure_ascii=False))
+        print("-" * 60)
+        
+        response = requests.post(
+            api_url,
+            json=payload,
+            headers={'Content-Type': 'application/json'},
+            timeout=30
+        )
+        
+        if response.status_code == 200:
+            print("\n✅ 报告发送成功")
+            try:
+                result = response.json()
+                print(f"  响应: {result}")
+            except:
+                pass
+            return True
+        else:
+            print(f"\n❌ 报告发送失败: HTTP {response.status_code}")
+            print(f"  响应: {response.text}")
+            return False
+    
+    except Exception as e:
+        print(f"❌ 发送报告失败: {e}")
+        return False
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='与基准数据对比并计算指标'
+    )
+    
+    parser.add_argument(
+        '--result-dir',
+        type=str,
+        required=True,
+        help='验证结果目录'
+    )
+    
+    parser.add_argument(
+        '--baseline-dir',
+        type=str,
+        default='MiniMax-M2.5',
+        help='基准数据目录 (默认: MiniMax-M2.5)'
+    )
+    
+    parser.add_argument(
+        '--provider',
+        type=str,
+        default=None,
+        help='Provider 名称（自动检测）'
+    )
+    
+    parser.add_argument(
+        '--output',
+        type=str,
+        default=None,
+        help='输出报告文件路径'
+    )
+    
+    parser.add_argument(
+        '--send-report',
+        action='store_true',
+        help='发送报告到 API'
+    )
+    
+    parser.add_argument(
+        '--api-url',
+        type=str,
+        default=None,
+        help='报告 API URL'
+    )
+    
+    args = parser.parse_args()
+    
+    print("=" * 60)
+    print("📊 MiniMax Provider Verifier - 基准对比")
+    print("=" * 60)
+    
+    # 检查目录
+    if not os.path.exists(args.result_dir):
+        print(f"❌ 结果目录不存在: {args.result_dir}")
+        return 1
+    
+    # 解析基准目录（支持相对路径）
+    baseline_dir = args.baseline_dir
+    if not os.path.isabs(baseline_dir):
+        # 尝试多个可能的位置
+        possible_paths = [
+            baseline_dir,
+            os.path.join(os.path.dirname(args.result_dir), baseline_dir),
+            os.path.join(os.getcwd(), baseline_dir),
+        ]
+        for path in possible_paths:
+            if os.path.exists(path):
+                baseline_dir = path
+                break
+    
+    if not os.path.exists(baseline_dir):
+        print(f"❌ 基准目录不存在: {baseline_dir}")
+        return 1
+    
+    print(f"📂 结果目录: {args.result_dir}")
+    print(f"📂 基准目录: {baseline_dir}")
+    
+    # 自动检测 provider
+    provider = args.provider
+    if not provider:
+        summary_files = find_summary_files(args.result_dir)
+        if summary_files:
+            # 从文件名提取 provider
+            basename = os.path.basename(summary_files[0])
+            provider = basename.replace('_summary.json', '')
+            print(f"📦 自动检测 provider: {provider}")
+    
+    if not provider:
+        print("❌ 无法自动检测 provider，请使用 --provider 参数指定")
+        return 1
+    
+    # 匹配循环
+    print("\n🔍 匹配结果与基准...")
+    matches = match_loops(args.result_dir, baseline_dir, provider)
+    
+    if not matches:
+        print("❌ 没有找到可匹配的数据")
+        return 1
+    
+    print(f"\n✅ 找到 {len(matches)} 组匹配")
+    
+    # 执行对比
+    print("\n🔄 开始对比...")
+    all_results = []
+    
+    for i, (result_summary, result_jsonl, baseline_summary, baseline_jsonl) in enumerate(matches, 1):
+        print(f"\n--- 对比 {i}/{len(matches)} ---")
+        print(f"   结果: {result_summary}")
+        print(f"   基准: {baseline_summary}")
+        
+        result = compare_single_loop(
+            result_summary, result_jsonl,
+            baseline_summary, baseline_jsonl
+        )
+        all_results.append(result)
+    
+    # 计算平均指标
+    avg_metrics = calculate_average_metrics(all_results)
+    
+    # 打印结果
+    print_comparison_table(all_results, avg_metrics)
+    
+    # 构建最终报告
+    report = {
+        'provider': provider,
+        'baseline_dir': baseline_dir,
+        'result_dir': args.result_dir,
+        'total_comparisons': len(all_results),
+        'successful_comparisons': len([r for r in all_results if r.get('status') == 'success']),
+        'generated_at': datetime.now().isoformat(),
+        'average_metrics': avg_metrics,
+        'comparisons': all_results
+    }
+    
+    # 保存报告
+    output_file = args.output
+    if not output_file:
+        output_file = os.path.join(args.result_dir, 'comparison_report.json')
+    
+    print(f"\n💾 保存报告到: {output_file}")
+    with open(output_file, 'w', encoding='utf-8') as f:
+        json.dump(report, f, indent=2, ensure_ascii=False)
+    print("✅ 报告保存成功")
+    
+    # 发送报告
+    if args.send_report:
+        send_report(report, args.api_url)
+    
+    print("\n🎉 对比完成！")
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/compare_with_baseline.py
+++ b/scripts/compare_with_baseline.py
@@ -86,11 +86,13 @@ def calculate_metrics_from_summary(data: Dict) -> Dict:
     success_count = data.get('success_count', 0)
     metrics['Query-Success-Rate'] = success_count / all_count if all_count > 0 else 0
     
-    finish_tool_calls_count = data.get('tool_calls_finish_tool_calls', 0)
-    metrics['Finish-ToolCalls-Rate'] = finish_tool_calls_count / all_count if all_count > 0 else 0
+    tool_calls_finish_tool_calls = data.get('tool_calls_finish_tool_calls', 0)
+    stop_finish_stop = data.get('stop_finish_stop', 0)
+    expected_tool_call_total_count = data.get('expected_tool_call_total_count', 0)
+    metrics['ToolCalls-Match-Rate'] = (tool_calls_finish_tool_calls + stop_finish_stop) / expected_tool_call_total_count if expected_tool_call_total_count > 0 else 0
     
     tool_calls_successful_count = data.get('tool_calls_successful_count', 0)
-    metrics['ToolCalls-Accuracy'] = tool_calls_successful_count / finish_tool_calls_count if finish_tool_calls_count > 0 else 0
+    metrics['ToolCalls-Accuracy'] = tool_calls_successful_count / tool_calls_finish_tool_calls if tool_calls_finish_tool_calls > 0 else 0
     
     error_only_reasoning_count = data.get('error_only_reasoning_count', 0)
     error_only_reasoning_checked_count = data.get('error_only_reasoning_checked_count', 0)
@@ -282,7 +284,7 @@ def calculate_average_metrics(all_results: List[Dict]) -> Dict:
     
     metric_keys = [
         'Query-Success-Rate',
-        'Finish-ToolCalls-Rate',
+        'ToolCalls-Match-Rate',
         'ToolCalls-Trigger-Similarity-F1',
         'ToolCalls-Accuracy',
         'Response-Success-Rate-Not-Only-Reasoning',
@@ -364,7 +366,7 @@ def print_comparison_table(all_results: List[Dict], avg_metrics: Dict):
             sim_str = f"{sim_f1*100:>10.2f}%" if sim_f1 is not None else "N/A".rjust(12)
             print(f"{loop_name:<15} {model:<25} "
                   f"{metrics.get('Query-Success-Rate', 0)*100:>8.2f}% "
-                  f"{metrics.get('Finish-ToolCalls-Rate', 0)*100:>8.2f}% "
+                  f"{metrics.get('ToolCalls-Match-Rate', 0)*100:>8.2f}% "
                   f"{sim_str} "
                   f"{metrics.get('ToolCalls-Accuracy', 0)*100:>8.2f}% "
                   f"{metrics.get('Response-Success-Rate-Not-Only-Reasoning', 0)*100:>8.2f}% "
@@ -372,7 +374,7 @@ def print_comparison_table(all_results: List[Dict], avg_metrics: Dict):
         else:
             print(f"{loop_name:<15} {model:<25} "
                   f"{metrics.get('Query-Success-Rate', 0)*100:>8.2f}% "
-                  f"{metrics.get('Finish-ToolCalls-Rate', 0)*100:>8.2f}% "
+                  f"{metrics.get('ToolCalls-Match-Rate', 0)*100:>8.2f}% "
                   f"{metrics.get('ToolCalls-Accuracy', 0)*100:>8.2f}% "
                   f"{metrics.get('Response-Success-Rate-Not-Only-Reasoning', 0)*100:>8.2f}% "
                   f"{metrics.get('Language-Following-Success-Rate', 0)*100:>8.2f}%")
@@ -383,7 +385,7 @@ def print_comparison_table(all_results: List[Dict], avg_metrics: Dict):
     if avg_metrics:
         print(f"\n📈 Average Metrics ({len(successful_results)} comparisons):")
         print(f"  1. Query-Success-Rate: {avg_metrics.get('Query-Success-Rate', 0):.4f} ({avg_metrics.get('Query-Success-Rate', 0)*100:.2f}%)")
-        print(f"  2. Finish-ToolCalls-Rate: {avg_metrics.get('Finish-ToolCalls-Rate', 0):.4f} ({avg_metrics.get('Finish-ToolCalls-Rate', 0)*100:.2f}%)")
+        print(f"  2. ToolCalls-Match-Rate: {avg_metrics.get('ToolCalls-Match-Rate', 0):.4f} ({avg_metrics.get('ToolCalls-Match-Rate', 0)*100:.2f}%)")
         if 'ToolCalls-Trigger-Similarity-F1' in avg_metrics:
             print(f"  3. ToolCalls-Trigger-Similarity-F1: {avg_metrics['ToolCalls-Trigger-Similarity-F1']:.4f} ({avg_metrics['ToolCalls-Trigger-Similarity-F1']*100:.2f}%)")
         print(f"  4. ToolCalls-Accuracy: {avg_metrics.get('ToolCalls-Accuracy', 0):.4f} ({avg_metrics.get('ToolCalls-Accuracy', 0)*100:.2f}%)")

--- a/validator/tool_calls.py
+++ b/validator/tool_calls.py
@@ -51,6 +51,8 @@ class ToolCallsValidator(BaseValidator):
             "stop_finish_stop": 0,               # expected stop, actual stop (TN)
             "tool_calls_finish_others": 0,
             "tool_calls_finish_others_detail": {},
+            # Expected tool call count (denominator for match rate)
+            "expected_tool_call_total_count": 0,  # Total labeled count (True + False)
             # Schema validation stats
             "tool_calls_schema_validation_error_count": 0,
             "tool_calls_successful_count": 0,
@@ -65,6 +67,10 @@ class ToolCallsValidator(BaseValidator):
             expected_tool_call = r.get("expected_tool_call")
 
             summary["tool_calls_total_count"] += tool_calls_count
+
+            # Count expected_tool_call labels
+            if expected_tool_call is True or expected_tool_call is False:
+                summary["expected_tool_call_total_count"] += 1
 
             # Classify into confusion matrix based on expected and actual
             actual_tool_call = (finish_reason == "tool_calls")

--- a/validator/tool_calls.py
+++ b/validator/tool_calls.py
@@ -44,10 +44,14 @@ class ToolCallsValidator(BaseValidator):
     def compute_summary(self, results: list[dict]) -> dict:
         """Compute summary statistics for tool calls validation."""
         summary = {
-            "tool_calls_finish_stop": 0,
-            "tool_calls_finish_tool_calls": 0,
+            # Confusion matrix: expected vs actual
+            "tool_calls_finish_tool_calls": 0,  # expected tool_call, actual tool_call (TP)
+            "tool_calls_finish_stop": 0,         # expected tool_call, actual stop (FN)
+            "stop_finish_tool_calls": 0,         # expected stop, actual tool_call (FP)
+            "stop_finish_stop": 0,               # expected stop, actual stop (TN)
             "tool_calls_finish_others": 0,
             "tool_calls_finish_others_detail": {},
+            # Schema validation stats
             "tool_calls_schema_validation_error_count": 0,
             "tool_calls_successful_count": 0,
             "tool_calls_total_count": 0,
@@ -58,25 +62,56 @@ class ToolCallsValidator(BaseValidator):
             finish_reason = r.get("tool_calls_finish_reason")
             tool_calls_valid = r.get("tool_calls_valid")
             tool_calls_count = r.get("tool_calls_count", 0)
+            expected_tool_call = r.get("expected_tool_call")
 
             summary["tool_calls_total_count"] += tool_calls_count
 
-            if finish_reason == "stop":
-                summary["tool_calls_finish_stop"] += 1
-            elif finish_reason == "tool_calls":
-                summary["tool_calls_finish_tool_calls"] += 1
-                if tool_calls_valid:
-                    summary["tool_calls_successful_count"] += 1
-                else:
-                    summary["tool_calls_schema_validation_error_count"] += 1
+            # Classify into confusion matrix based on expected and actual
+            actual_tool_call = (finish_reason == "tool_calls")
+            actual_stop = (finish_reason == "stop")
 
-                count_key = str(tool_calls_count)
-                summary["tool_calls_count_distribution"].setdefault(count_key, 0)
-                summary["tool_calls_count_distribution"][count_key] += 1
-            elif finish_reason:
-                summary["tool_calls_finish_others"] += 1
-                summary["tool_calls_finish_others_detail"].setdefault(finish_reason, 0)
-                summary["tool_calls_finish_others_detail"][finish_reason] += 1
+            if expected_tool_call is True:
+                if actual_tool_call:
+                    summary["tool_calls_finish_tool_calls"] += 1
+                    if tool_calls_valid:
+                        summary["tool_calls_successful_count"] += 1
+                    else:
+                        summary["tool_calls_schema_validation_error_count"] += 1
+                    count_key = str(tool_calls_count)
+                    summary["tool_calls_count_distribution"].setdefault(count_key, 0)
+                    summary["tool_calls_count_distribution"][count_key] += 1
+                elif actual_stop:
+                    summary["tool_calls_finish_stop"] += 1
+                elif finish_reason:
+                    summary["tool_calls_finish_others"] += 1
+                    summary["tool_calls_finish_others_detail"].setdefault(finish_reason, 0)
+                    summary["tool_calls_finish_others_detail"][finish_reason] += 1
+            elif expected_tool_call is False:
+                if actual_tool_call:
+                    summary["stop_finish_tool_calls"] += 1
+                elif actual_stop:
+                    summary["stop_finish_stop"] += 1
+                elif finish_reason:
+                    summary["tool_calls_finish_others"] += 1
+                    summary["tool_calls_finish_others_detail"].setdefault(finish_reason, 0)
+                    summary["tool_calls_finish_others_detail"][finish_reason] += 1
+            else:
+                # expected_tool_call is None (legacy data without label)
+                if actual_tool_call:
+                    summary["tool_calls_finish_tool_calls"] += 1
+                    if tool_calls_valid:
+                        summary["tool_calls_successful_count"] += 1
+                    else:
+                        summary["tool_calls_schema_validation_error_count"] += 1
+                    count_key = str(tool_calls_count)
+                    summary["tool_calls_count_distribution"].setdefault(count_key, 0)
+                    summary["tool_calls_count_distribution"][count_key] += 1
+                elif actual_stop:
+                    summary["tool_calls_finish_stop"] += 1
+                elif finish_reason:
+                    summary["tool_calls_finish_others"] += 1
+                    summary["tool_calls_finish_others_detail"].setdefault(finish_reason, 0)
+                    summary["tool_calls_finish_others_detail"][finish_reason] += 1
 
         return summary
 

--- a/verify.py
+++ b/verify.py
@@ -122,6 +122,7 @@ class ValidatorRunner:
             req["model"] = self.model
         # Remove custom fields, do not pass to API
         req.pop("check_type", None)
+        req.pop("expected_tool_call", None)
         return req
 
     def read_jsonl(self, file_path: str) -> list[dict]:
@@ -281,6 +282,7 @@ class ValidatorRunner:
                 "duration_ms": duration_ms,
                 "hash": prepared_req["hash"],
                 "provider": response.get("provider", ''),
+                "expected_tool_call": prepared_req.get("raw", {}).get("expected_tool_call"),
             }
             
             # Extract finish_reason and content for backward compatibility
@@ -446,6 +448,12 @@ class ValidatorRunner:
             summary["success_rate"] = round(summary["success_count"] / summary["all_count"], 2)
         else:
             summary["success_rate"] = 0.0
+        
+        # Compute tool calls accuracy: (matched / success_count)
+        # matched = tool_calls_finish_tool_calls (TP) + stop_finish_stop (TN)
+        if summary["success_count"] > 0 and "tool_calls_finish_tool_calls" in summary:
+            matched = summary.get("tool_calls_finish_tool_calls", 0) + summary.get("stop_finish_stop", 0)
+            summary["tool_calls_accuracy"] = round(matched / summary["success_count"], 4)
         
         self.summary = summary
 

--- a/verify.py
+++ b/verify.py
@@ -50,6 +50,10 @@ class ValidatorRunner:
         extra_body: Optional[dict] = None,
         incremental: bool = False,
         validators: Optional[list[BaseValidator]] = None,
+        stream: bool = False,
+        debug: bool = False,
+        openrouter_provider: Optional[str] = None,
+        api_format: str = "openai",
     ):
         self.model = model
         self.base_url = base_url
@@ -62,6 +66,10 @@ class ValidatorRunner:
         self.output_file = output_file
         self.summary_file = summary_file
         self.incremental = incremental
+        self.stream = stream
+        self.debug = debug
+        self.openrouter_provider = openrouter_provider
+        self.api_format = api_format
         
         # Validators management
         # If no validators specified, use default ToolCallsValidator


### PR DESCRIPTION
## Summary
- Add `expected_tool_call` field support in tool_calls validator for calculating match rate
- Implement confusion matrix metrics (TP/FN/FP/TN) for tool calls evaluation:
  - `tool_calls_finish_tool_calls`: expected tool_call, actual tool_call (True Positive)
  - `tool_calls_finish_stop`: expected tool_call, actual stop (False Negative)
  - `stop_finish_tool_calls`: expected stop, actual tool_call (False Positive)
  - `stop_finish_stop`: expected stop, actual stop (True Negative)
- Update sample.jsonl with `expected_tool_call` labels
- Update documentation and changelog

## Test plan
- [x] Verify tool_calls validator correctly classifies results based on expected vs actual
- [x] Check confusion matrix counts are accurate
- [x] Ensure backward compatibility with legacy data (without expected_tool_call field)


Made with [Cursor](https://cursor.com)