### PR TITLE
feat: add array command validation and update M2.5/M2.7 baseline

### DIFF
--- a/output-dir/MiniMax-M2.5/loop_01/MiniMax-M2.5/MiniMax-M2.5_summary.json
+++ b/output-dir/MiniMax-M2.5/loop_01/MiniMax-M2.5/MiniMax-M2.5_summary.json
@@ -1,0 +1,32 @@
+{
+    "model": "minimax-m2.5",
+    "success_count": 101,
+    "failure_count": 0,
+    "all_count": 101,
+    "tool_calls_finish_tool_calls": 84,
+    "tool_calls_finish_stop": 0,
+    "stop_finish_tool_calls": 1,
+    "stop_finish_stop": 14,
+    "tool_calls_finish_others": 0,
+    "tool_calls_finish_others_detail": {},
+    "expected_tool_call_total_count": 99,
+    "tool_calls_schema_validation_error_count": 2,
+    "tool_calls_successful_count": 82,
+    "tool_calls_total_count": 162,
+    "tool_calls_count_distribution": {
+        "1": 50,
+        "2": 9,
+        "3": 16,
+        "4": 5,
+        "5": 3,
+        "9": 1
+    },
+    "language_following_checked_count": 2,
+    "language_following_valid_count": 2,
+    "language_following_invalid_count": 0,
+    "error_only_reasoning_checked_count": 101,
+    "error_only_reasoning_count": 0,
+    "error_only_reasoning_rate": 0.0,
+    "success_rate": 1.0,
+    "tool_calls_accuracy": 0.9703
+}

--- a/output-dir/MiniMax-M2.5/loop_01/MiniMax-M2.5/batch_report.json
+++ b/output-dir/MiniMax-M2.5/loop_01/MiniMax-M2.5/batch_report.json
@@ -1,0 +1,48 @@
+{
+  "test_file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.5_retry_20260401_200428/loop_01/MiniMax-M2.5/test_data.jsonl",
+  "total_providers": 1,
+  "successful_providers": 1,
+  "failed_providers": 0,
+  "provider_results": [
+    {
+      "provider": "MiniMax-M2.5",
+      "status": "success",
+      "summary": {
+        "model": "minimax-m2.5",
+        "success_count": 101,
+        "failure_count": 0,
+        "all_count": 101,
+        "tool_calls_finish_tool_calls": 84,
+        "tool_calls_finish_stop": 0,
+        "stop_finish_tool_calls": 1,
+        "stop_finish_stop": 14,
+        "tool_calls_finish_others": 0,
+        "tool_calls_finish_others_detail": {},
+        "expected_tool_call_total_count": 99,
+        "tool_calls_schema_validation_error_count": 2,
+        "tool_calls_successful_count": 82,
+        "tool_calls_total_count": 162,
+        "tool_calls_count_distribution": {
+          "1": 50,
+          "2": 9,
+          "3": 16,
+          "4": 5,
+          "5": 3,
+          "9": 1
+        },
+        "language_following_checked_count": 2,
+        "language_following_valid_count": 2,
+        "language_following_invalid_count": 0,
+        "error_only_reasoning_checked_count": 101,
+        "error_only_reasoning_count": 0,
+        "error_only_reasoning_rate": 0.0,
+        "success_rate": 1.0,
+        "tool_calls_accuracy": 0.9703
+      },
+      "output_file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.5_retry_20260401_200428/loop_01/MiniMax-M2.5/MiniMax-M2.5_results.jsonl",
+      "summary_file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.5_retry_20260401_200428/loop_01/MiniMax-M2.5/MiniMax-M2.5_summary.json",
+      "completed_at": "2026-04-01T20:08:23.990113"
+    }
+  ],
+  "generated_at": "2026-04-01T20:08:24.001270"
+}

--- a/output-dir/MiniMax-M2.5/loop_02/MiniMax-M2.5/MiniMax-M2.5_summary.json
+++ b/output-dir/MiniMax-M2.5/loop_02/MiniMax-M2.5/MiniMax-M2.5_summary.json
@@ -1,0 +1,32 @@
+{
+    "model": "minimax-m2.5",
+    "success_count": 101,
+    "failure_count": 0,
+    "all_count": 101,
+    "tool_calls_finish_tool_calls": 84,
+    "tool_calls_finish_stop": 0,
+    "stop_finish_tool_calls": 0,
+    "stop_finish_stop": 15,
+    "tool_calls_finish_others": 0,
+    "tool_calls_finish_others_detail": {},
+    "expected_tool_call_total_count": 99,
+    "tool_calls_schema_validation_error_count": 1,
+    "tool_calls_successful_count": 83,
+    "tool_calls_total_count": 159,
+    "tool_calls_count_distribution": {
+        "1": 51,
+        "2": 9,
+        "3": 14,
+        "4": 6,
+        "5": 3,
+        "9": 1
+    },
+    "language_following_checked_count": 2,
+    "language_following_valid_count": 1,
+    "language_following_invalid_count": 1,
+    "error_only_reasoning_checked_count": 101,
+    "error_only_reasoning_count": 0,
+    "error_only_reasoning_rate": 0.0,
+    "success_rate": 1.0,
+    "tool_calls_accuracy": 0.9802
+}

--- a/output-dir/MiniMax-M2.5/loop_02/MiniMax-M2.5/batch_report.json
+++ b/output-dir/MiniMax-M2.5/loop_02/MiniMax-M2.5/batch_report.json
@@ -1,0 +1,48 @@
+{
+  "test_file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.5_retry_20260401_200428/loop_02/MiniMax-M2.5/test_data.jsonl",
+  "total_providers": 1,
+  "successful_providers": 1,
+  "failed_providers": 0,
+  "provider_results": [
+    {
+      "provider": "MiniMax-M2.5",
+      "status": "success",
+      "summary": {
+        "model": "minimax-m2.5",
+        "success_count": 101,
+        "failure_count": 0,
+        "all_count": 101,
+        "tool_calls_finish_tool_calls": 84,
+        "tool_calls_finish_stop": 0,
+        "stop_finish_tool_calls": 0,
+        "stop_finish_stop": 15,
+        "tool_calls_finish_others": 0,
+        "tool_calls_finish_others_detail": {},
+        "expected_tool_call_total_count": 99,
+        "tool_calls_schema_validation_error_count": 1,
+        "tool_calls_successful_count": 83,
+        "tool_calls_total_count": 159,
+        "tool_calls_count_distribution": {
+          "1": 51,
+          "2": 9,
+          "3": 14,
+          "4": 6,
+          "5": 3,
+          "9": 1
+        },
+        "language_following_checked_count": 2,
+        "language_following_valid_count": 1,
+        "language_following_invalid_count": 1,
+        "error_only_reasoning_checked_count": 101,
+        "error_only_reasoning_count": 0,
+        "error_only_reasoning_rate": 0.0,
+        "success_rate": 1.0,
+        "tool_calls_accuracy": 0.9802
+      },
+      "output_file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.5_retry_20260401_200428/loop_02/MiniMax-M2.5/MiniMax-M2.5_results.jsonl",
+      "summary_file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.5_retry_20260401_200428/loop_02/MiniMax-M2.5/MiniMax-M2.5_summary.json",
+      "completed_at": "2026-04-01T20:17:58.817593"
+    }
+  ],
+  "generated_at": "2026-04-01T20:17:58.833968"
+}

--- a/output-dir/MiniMax-M2.5/loop_03/MiniMax-M2.5/MiniMax-M2.5_summary.json
+++ b/output-dir/MiniMax-M2.5/loop_03/MiniMax-M2.5/MiniMax-M2.5_summary.json
@@ -1,0 +1,32 @@
+{
+    "model": "minimax-m2.5",
+    "success_count": 101,
+    "failure_count": 0,
+    "all_count": 101,
+    "tool_calls_finish_tool_calls": 84,
+    "tool_calls_finish_stop": 0,
+    "stop_finish_tool_calls": 4,
+    "stop_finish_stop": 11,
+    "tool_calls_finish_others": 0,
+    "tool_calls_finish_others_detail": {},
+    "expected_tool_call_total_count": 99,
+    "tool_calls_schema_validation_error_count": 3,
+    "tool_calls_successful_count": 81,
+    "tool_calls_total_count": 164,
+    "tool_calls_count_distribution": {
+        "1": 52,
+        "2": 7,
+        "3": 14,
+        "4": 7,
+        "5": 3,
+        "9": 1
+    },
+    "language_following_checked_count": 2,
+    "language_following_valid_count": 2,
+    "language_following_invalid_count": 0,
+    "error_only_reasoning_checked_count": 101,
+    "error_only_reasoning_count": 0,
+    "error_only_reasoning_rate": 0.0,
+    "success_rate": 1.0,
+    "tool_calls_accuracy": 0.9406
+}

--- a/output-dir/MiniMax-M2.5/loop_03/MiniMax-M2.5/batch_report.json
+++ b/output-dir/MiniMax-M2.5/loop_03/MiniMax-M2.5/batch_report.json
@@ -1,0 +1,48 @@
+{
+  "test_file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.5_retry_20260401_200428/loop_03/MiniMax-M2.5/test_data.jsonl",
+  "total_providers": 1,
+  "successful_providers": 1,
+  "failed_providers": 0,
+  "provider_results": [
+    {
+      "provider": "MiniMax-M2.5",
+      "status": "success",
+      "summary": {
+        "model": "minimax-m2.5",
+        "success_count": 101,
+        "failure_count": 0,
+        "all_count": 101,
+        "tool_calls_finish_tool_calls": 84,
+        "tool_calls_finish_stop": 0,
+        "stop_finish_tool_calls": 4,
+        "stop_finish_stop": 11,
+        "tool_calls_finish_others": 0,
+        "tool_calls_finish_others_detail": {},
+        "expected_tool_call_total_count": 99,
+        "tool_calls_schema_validation_error_count": 3,
+        "tool_calls_successful_count": 81,
+        "tool_calls_total_count": 164,
+        "tool_calls_count_distribution": {
+          "1": 52,
+          "2": 7,
+          "3": 14,
+          "4": 7,
+          "5": 3,
+          "9": 1
+        },
+        "language_following_checked_count": 2,
+        "language_following_valid_count": 2,
+        "language_following_invalid_count": 0,
+        "error_only_reasoning_checked_count": 101,
+        "error_only_reasoning_count": 0,
+        "error_only_reasoning_rate": 0.0,
+        "success_rate": 1.0,
+        "tool_calls_accuracy": 0.9406
+      },
+      "output_file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.5_retry_20260401_200428/loop_03/MiniMax-M2.5/MiniMax-M2.5_results.jsonl",
+      "summary_file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.5_retry_20260401_200428/loop_03/MiniMax-M2.5/MiniMax-M2.5_summary.json",
+      "completed_at": "2026-04-01T20:20:13.947996"
+    }
+  ],
+  "generated_at": "2026-04-01T20:20:13.953959"
+}

--- a/output-dir/MiniMax-M2.5/loop_04/MiniMax-M2.5/MiniMax-M2.5_summary.json
+++ b/output-dir/MiniMax-M2.5/loop_04/MiniMax-M2.5/MiniMax-M2.5_summary.json
@@ -1,0 +1,32 @@
+{
+    "model": "minimax-m2.5",
+    "success_count": 101,
+    "failure_count": 0,
+    "all_count": 101,
+    "tool_calls_finish_tool_calls": 84,
+    "tool_calls_finish_stop": 0,
+    "stop_finish_tool_calls": 0,
+    "stop_finish_stop": 15,
+    "tool_calls_finish_others": 0,
+    "tool_calls_finish_others_detail": {},
+    "expected_tool_call_total_count": 99,
+    "tool_calls_schema_validation_error_count": 4,
+    "tool_calls_successful_count": 80,
+    "tool_calls_total_count": 158,
+    "tool_calls_count_distribution": {
+        "1": 51,
+        "2": 10,
+        "3": 12,
+        "4": 8,
+        "5": 2,
+        "9": 1
+    },
+    "language_following_checked_count": 2,
+    "language_following_valid_count": 2,
+    "language_following_invalid_count": 0,
+    "error_only_reasoning_checked_count": 101,
+    "error_only_reasoning_count": 0,
+    "error_only_reasoning_rate": 0.0,
+    "success_rate": 1.0,
+    "tool_calls_accuracy": 0.9802
+}

--- a/output-dir/MiniMax-M2.5/loop_04/MiniMax-M2.5/batch_report.json
+++ b/output-dir/MiniMax-M2.5/loop_04/MiniMax-M2.5/batch_report.json
@@ -1,0 +1,48 @@
+{
+  "test_file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.5_retry_20260401_200428/loop_04/MiniMax-M2.5/test_data.jsonl",
+  "total_providers": 1,
+  "successful_providers": 1,
+  "failed_providers": 0,
+  "provider_results": [
+    {
+      "provider": "MiniMax-M2.5",
+      "status": "success",
+      "summary": {
+        "model": "minimax-m2.5",
+        "success_count": 101,
+        "failure_count": 0,
+        "all_count": 101,
+        "tool_calls_finish_tool_calls": 84,
+        "tool_calls_finish_stop": 0,
+        "stop_finish_tool_calls": 0,
+        "stop_finish_stop": 15,
+        "tool_calls_finish_others": 0,
+        "tool_calls_finish_others_detail": {},
+        "expected_tool_call_total_count": 99,
+        "tool_calls_schema_validation_error_count": 4,
+        "tool_calls_successful_count": 80,
+        "tool_calls_total_count": 158,
+        "tool_calls_count_distribution": {
+          "1": 51,
+          "2": 10,
+          "3": 12,
+          "4": 8,
+          "5": 2,
+          "9": 1
+        },
+        "language_following_checked_count": 2,
+        "language_following_valid_count": 2,
+        "language_following_invalid_count": 0,
+        "error_only_reasoning_checked_count": 101,
+        "error_only_reasoning_count": 0,
+        "error_only_reasoning_rate": 0.0,
+        "success_rate": 1.0,
+        "tool_calls_accuracy": 0.9802
+      },
+      "output_file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.5_retry_20260401_200428/loop_04/MiniMax-M2.5/MiniMax-M2.5_results.jsonl",
+      "summary_file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.5_retry_20260401_200428/loop_04/MiniMax-M2.5/MiniMax-M2.5_summary.json",
+      "completed_at": "2026-04-01T20:22:25.248605"
+    }
+  ],
+  "generated_at": "2026-04-01T20:22:25.258381"
+}

--- a/output-dir/MiniMax-M2.5/loop_05/MiniMax-M2.5/MiniMax-M2.5_summary.json
+++ b/output-dir/MiniMax-M2.5/loop_05/MiniMax-M2.5/MiniMax-M2.5_summary.json
@@ -1,0 +1,32 @@
+{
+    "model": "minimax-m2.5",
+    "success_count": 101,
+    "failure_count": 0,
+    "all_count": 101,
+    "tool_calls_finish_tool_calls": 84,
+    "tool_calls_finish_stop": 0,
+    "stop_finish_tool_calls": 0,
+    "stop_finish_stop": 15,
+    "tool_calls_finish_others": 0,
+    "tool_calls_finish_others_detail": {},
+    "expected_tool_call_total_count": 99,
+    "tool_calls_schema_validation_error_count": 3,
+    "tool_calls_successful_count": 81,
+    "tool_calls_total_count": 157,
+    "tool_calls_count_distribution": {
+        "1": 52,
+        "2": 9,
+        "3": 13,
+        "4": 6,
+        "5": 3,
+        "9": 1
+    },
+    "language_following_checked_count": 2,
+    "language_following_valid_count": 1,
+    "language_following_invalid_count": 1,
+    "error_only_reasoning_checked_count": 101,
+    "error_only_reasoning_count": 0,
+    "error_only_reasoning_rate": 0.0,
+    "success_rate": 1.0,
+    "tool_calls_accuracy": 0.9802
+}

--- a/output-dir/MiniMax-M2.5/loop_05/MiniMax-M2.5/batch_report.json
+++ b/output-dir/MiniMax-M2.5/loop_05/MiniMax-M2.5/batch_report.json
@@ -1,0 +1,48 @@
+{
+  "test_file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.5_retry_20260401_200428/loop_05/MiniMax-M2.5/test_data.jsonl",
+  "total_providers": 1,
+  "successful_providers": 1,
+  "failed_providers": 0,
+  "provider_results": [
+    {
+      "provider": "MiniMax-M2.5",
+      "status": "success",
+      "summary": {
+        "model": "minimax-m2.5",
+        "success_count": 101,
+        "failure_count": 0,
+        "all_count": 101,
+        "tool_calls_finish_tool_calls": 84,
+        "tool_calls_finish_stop": 0,
+        "stop_finish_tool_calls": 0,
+        "stop_finish_stop": 15,
+        "tool_calls_finish_others": 0,
+        "tool_calls_finish_others_detail": {},
+        "expected_tool_call_total_count": 99,
+        "tool_calls_schema_validation_error_count": 3,
+        "tool_calls_successful_count": 81,
+        "tool_calls_total_count": 157,
+        "tool_calls_count_distribution": {
+          "1": 52,
+          "2": 9,
+          "3": 13,
+          "4": 6,
+          "5": 3,
+          "9": 1
+        },
+        "language_following_checked_count": 2,
+        "language_following_valid_count": 1,
+        "language_following_invalid_count": 1,
+        "error_only_reasoning_checked_count": 101,
+        "error_only_reasoning_count": 0,
+        "error_only_reasoning_rate": 0.0,
+        "success_rate": 1.0,
+        "tool_calls_accuracy": 0.9802
+      },
+      "output_file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.5_retry_20260401_200428/loop_05/MiniMax-M2.5/MiniMax-M2.5_results.jsonl",
+      "summary_file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.5_retry_20260401_200428/loop_05/MiniMax-M2.5/MiniMax-M2.5_summary.json",
+      "completed_at": "2026-04-01T20:24:37.843618"
+    }
+  ],
+  "generated_at": "2026-04-01T20:24:37.850076"
+}

--- a/output-dir/MiniMax-M2.5/loop_06/MiniMax-M2.5/MiniMax-M2.5_summary.json
+++ b/output-dir/MiniMax-M2.5/loop_06/MiniMax-M2.5/MiniMax-M2.5_summary.json
@@ -1,0 +1,32 @@
+{
+    "model": "minimax-m2.5",
+    "success_count": 101,
+    "failure_count": 0,
+    "all_count": 101,
+    "tool_calls_finish_tool_calls": 84,
+    "tool_calls_finish_stop": 0,
+    "stop_finish_tool_calls": 1,
+    "stop_finish_stop": 14,
+    "tool_calls_finish_others": 0,
+    "tool_calls_finish_others_detail": {},
+    "expected_tool_call_total_count": 99,
+    "tool_calls_schema_validation_error_count": 4,
+    "tool_calls_successful_count": 80,
+    "tool_calls_total_count": 163,
+    "tool_calls_count_distribution": {
+        "1": 48,
+        "2": 11,
+        "3": 15,
+        "4": 7,
+        "5": 2,
+        "9": 1
+    },
+    "language_following_checked_count": 2,
+    "language_following_valid_count": 2,
+    "language_following_invalid_count": 0,
+    "error_only_reasoning_checked_count": 101,
+    "error_only_reasoning_count": 0,
+    "error_only_reasoning_rate": 0.0,
+    "success_rate": 1.0,
+    "tool_calls_accuracy": 0.9703
+}

--- a/output-dir/MiniMax-M2.5/loop_06/MiniMax-M2.5/batch_report.json
+++ b/output-dir/MiniMax-M2.5/loop_06/MiniMax-M2.5/batch_report.json
@@ -1,0 +1,48 @@
+{
+  "test_file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.5_retry_20260401_200428/loop_06/MiniMax-M2.5/test_data.jsonl",
+  "total_providers": 1,
+  "successful_providers": 1,
+  "failed_providers": 0,
+  "provider_results": [
+    {
+      "provider": "MiniMax-M2.5",
+      "status": "success",
+      "summary": {
+        "model": "minimax-m2.5",
+        "success_count": 101,
+        "failure_count": 0,
+        "all_count": 101,
+        "tool_calls_finish_tool_calls": 84,
+        "tool_calls_finish_stop": 0,
+        "stop_finish_tool_calls": 1,
+        "stop_finish_stop": 14,
+        "tool_calls_finish_others": 0,
+        "tool_calls_finish_others_detail": {},
+        "expected_tool_call_total_count": 99,
+        "tool_calls_schema_validation_error_count": 4,
+        "tool_calls_successful_count": 80,
+        "tool_calls_total_count": 163,
+        "tool_calls_count_distribution": {
+          "1": 48,
+          "2": 11,
+          "3": 15,
+          "4": 7,
+          "5": 2,
+          "9": 1
+        },
+        "language_following_checked_count": 2,
+        "language_following_valid_count": 2,
+        "language_following_invalid_count": 0,
+        "error_only_reasoning_checked_count": 101,
+        "error_only_reasoning_count": 0,
+        "error_only_reasoning_rate": 0.0,
+        "success_rate": 1.0,
+        "tool_calls_accuracy": 0.9703
+      },
+      "output_file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.5_retry_20260401_200428/loop_06/MiniMax-M2.5/MiniMax-M2.5_results.jsonl",
+      "summary_file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.5_retry_20260401_200428/loop_06/MiniMax-M2.5/MiniMax-M2.5_summary.json",
+      "completed_at": "2026-04-01T20:26:29.154239"
+    }
+  ],
+  "generated_at": "2026-04-01T20:26:29.160049"
+}

--- a/output-dir/MiniMax-M2.5/loop_07/MiniMax-M2.5/MiniMax-M2.5_summary.json
+++ b/output-dir/MiniMax-M2.5/loop_07/MiniMax-M2.5/MiniMax-M2.5_summary.json
@@ -1,0 +1,32 @@
+{
+    "model": "minimax-m2.5",
+    "success_count": 101,
+    "failure_count": 0,
+    "all_count": 101,
+    "language_following_checked_count": 2,
+    "language_following_valid_count": 2,
+    "language_following_invalid_count": 0,
+    "tool_calls_finish_tool_calls": 84,
+    "tool_calls_finish_stop": 0,
+    "stop_finish_tool_calls": 0,
+    "stop_finish_stop": 15,
+    "tool_calls_finish_others": 0,
+    "tool_calls_finish_others_detail": {},
+    "expected_tool_call_total_count": 99,
+    "tool_calls_schema_validation_error_count": 5,
+    "tool_calls_successful_count": 79,
+    "tool_calls_total_count": 158,
+    "tool_calls_count_distribution": {
+        "1": 51,
+        "2": 10,
+        "3": 13,
+        "4": 6,
+        "5": 3,
+        "9": 1
+    },
+    "error_only_reasoning_checked_count": 101,
+    "error_only_reasoning_count": 0,
+    "error_only_reasoning_rate": 0.0,
+    "success_rate": 1.0,
+    "tool_calls_accuracy": 0.9802
+}

--- a/output-dir/MiniMax-M2.5/loop_07/MiniMax-M2.5/batch_report.json
+++ b/output-dir/MiniMax-M2.5/loop_07/MiniMax-M2.5/batch_report.json
@@ -1,0 +1,48 @@
+{
+  "test_file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.5_retry_20260401_200428/loop_07/MiniMax-M2.5/test_data.jsonl",
+  "total_providers": 1,
+  "successful_providers": 1,
+  "failed_providers": 0,
+  "provider_results": [
+    {
+      "provider": "MiniMax-M2.5",
+      "status": "success",
+      "summary": {
+        "model": "minimax-m2.5",
+        "success_count": 101,
+        "failure_count": 0,
+        "all_count": 101,
+        "language_following_checked_count": 2,
+        "language_following_valid_count": 2,
+        "language_following_invalid_count": 0,
+        "tool_calls_finish_tool_calls": 84,
+        "tool_calls_finish_stop": 0,
+        "stop_finish_tool_calls": 0,
+        "stop_finish_stop": 15,
+        "tool_calls_finish_others": 0,
+        "tool_calls_finish_others_detail": {},
+        "expected_tool_call_total_count": 99,
+        "tool_calls_schema_validation_error_count": 5,
+        "tool_calls_successful_count": 79,
+        "tool_calls_total_count": 158,
+        "tool_calls_count_distribution": {
+          "1": 51,
+          "2": 10,
+          "3": 13,
+          "4": 6,
+          "5": 3,
+          "9": 1
+        },
+        "error_only_reasoning_checked_count": 101,
+        "error_only_reasoning_count": 0,
+        "error_only_reasoning_rate": 0.0,
+        "success_rate": 1.0,
+        "tool_calls_accuracy": 0.9802
+      },
+      "output_file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.5_retry_20260401_200428/loop_07/MiniMax-M2.5/MiniMax-M2.5_results.jsonl",
+      "summary_file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.5_retry_20260401_200428/loop_07/MiniMax-M2.5/MiniMax-M2.5_summary.json",
+      "completed_at": "2026-04-01T20:28:25.584002"
+    }
+  ],
+  "generated_at": "2026-04-01T20:28:25.591058"
+}

--- a/output-dir/MiniMax-M2.5/loop_08/MiniMax-M2.5/MiniMax-M2.5_summary.json
+++ b/output-dir/MiniMax-M2.5/loop_08/MiniMax-M2.5/MiniMax-M2.5_summary.json
@@ -1,0 +1,32 @@
+{
+    "model": "minimax-m2.5",
+    "success_count": 101,
+    "failure_count": 0,
+    "all_count": 101,
+    "language_following_checked_count": 2,
+    "language_following_valid_count": 2,
+    "language_following_invalid_count": 0,
+    "tool_calls_finish_tool_calls": 84,
+    "tool_calls_finish_stop": 0,
+    "stop_finish_tool_calls": 1,
+    "stop_finish_stop": 14,
+    "tool_calls_finish_others": 0,
+    "tool_calls_finish_others_detail": {},
+    "expected_tool_call_total_count": 99,
+    "tool_calls_schema_validation_error_count": 2,
+    "tool_calls_successful_count": 82,
+    "tool_calls_total_count": 163,
+    "tool_calls_count_distribution": {
+        "2": 10,
+        "1": 49,
+        "3": 15,
+        "4": 6,
+        "5": 3,
+        "9": 1
+    },
+    "error_only_reasoning_checked_count": 101,
+    "error_only_reasoning_count": 0,
+    "error_only_reasoning_rate": 0.0,
+    "success_rate": 1.0,
+    "tool_calls_accuracy": 0.9703
+}

--- a/output-dir/MiniMax-M2.5/loop_08/MiniMax-M2.5/batch_report.json
+++ b/output-dir/MiniMax-M2.5/loop_08/MiniMax-M2.5/batch_report.json
@@ -1,0 +1,48 @@
+{
+  "test_file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.5_retry_20260401_200428/loop_08/MiniMax-M2.5/test_data.jsonl",
+  "total_providers": 1,
+  "successful_providers": 1,
+  "failed_providers": 0,
+  "provider_results": [
+    {
+      "provider": "MiniMax-M2.5",
+      "status": "success",
+      "summary": {
+        "model": "minimax-m2.5",
+        "success_count": 101,
+        "failure_count": 0,
+        "all_count": 101,
+        "language_following_checked_count": 2,
+        "language_following_valid_count": 2,
+        "language_following_invalid_count": 0,
+        "tool_calls_finish_tool_calls": 84,
+        "tool_calls_finish_stop": 0,
+        "stop_finish_tool_calls": 1,
+        "stop_finish_stop": 14,
+        "tool_calls_finish_others": 0,
+        "tool_calls_finish_others_detail": {},
+        "expected_tool_call_total_count": 99,
+        "tool_calls_schema_validation_error_count": 2,
+        "tool_calls_successful_count": 82,
+        "tool_calls_total_count": 163,
+        "tool_calls_count_distribution": {
+          "2": 10,
+          "1": 49,
+          "3": 15,
+          "4": 6,
+          "5": 3,
+          "9": 1
+        },
+        "error_only_reasoning_checked_count": 101,
+        "error_only_reasoning_count": 0,
+        "error_only_reasoning_rate": 0.0,
+        "success_rate": 1.0,
+        "tool_calls_accuracy": 0.9703
+      },
+      "output_file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.5_retry_20260401_200428/loop_08/MiniMax-M2.5/MiniMax-M2.5_results.jsonl",
+      "summary_file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.5_retry_20260401_200428/loop_08/MiniMax-M2.5/MiniMax-M2.5_summary.json",
+      "completed_at": "2026-04-01T20:30:08.708950"
+    }
+  ],
+  "generated_at": "2026-04-01T20:30:08.714391"
+}

--- a/output-dir/MiniMax-M2.5/loop_09/MiniMax-M2.5/MiniMax-M2.5_summary.json
+++ b/output-dir/MiniMax-M2.5/loop_09/MiniMax-M2.5/MiniMax-M2.5_summary.json
@@ -1,0 +1,32 @@
+{
+    "model": "minimax-m2.5",
+    "success_count": 101,
+    "failure_count": 0,
+    "all_count": 101,
+    "language_following_checked_count": 2,
+    "language_following_valid_count": 1,
+    "language_following_invalid_count": 1,
+    "tool_calls_finish_tool_calls": 84,
+    "tool_calls_finish_stop": 0,
+    "stop_finish_tool_calls": 1,
+    "stop_finish_stop": 14,
+    "tool_calls_finish_others": 0,
+    "tool_calls_finish_others_detail": {},
+    "expected_tool_call_total_count": 99,
+    "tool_calls_schema_validation_error_count": 3,
+    "tool_calls_successful_count": 81,
+    "tool_calls_total_count": 167,
+    "tool_calls_count_distribution": {
+        "2": 11,
+        "1": 46,
+        "3": 18,
+        "4": 5,
+        "5": 3,
+        "9": 1
+    },
+    "error_only_reasoning_checked_count": 101,
+    "error_only_reasoning_count": 0,
+    "error_only_reasoning_rate": 0.0,
+    "success_rate": 1.0,
+    "tool_calls_accuracy": 0.9703
+}

--- a/output-dir/MiniMax-M2.5/loop_09/MiniMax-M2.5/batch_report.json
+++ b/output-dir/MiniMax-M2.5/loop_09/MiniMax-M2.5/batch_report.json
@@ -1,0 +1,48 @@
+{
+  "test_file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.5_retry_20260401_200428/loop_09/MiniMax-M2.5/test_data.jsonl",
+  "total_providers": 1,
+  "successful_providers": 1,
+  "failed_providers": 0,
+  "provider_results": [
+    {
+      "provider": "MiniMax-M2.5",
+      "status": "success",
+      "summary": {
+        "model": "minimax-m2.5",
+        "success_count": 101,
+        "failure_count": 0,
+        "all_count": 101,
+        "language_following_checked_count": 2,
+        "language_following_valid_count": 1,
+        "language_following_invalid_count": 1,
+        "tool_calls_finish_tool_calls": 84,
+        "tool_calls_finish_stop": 0,
+        "stop_finish_tool_calls": 1,
+        "stop_finish_stop": 14,
+        "tool_calls_finish_others": 0,
+        "tool_calls_finish_others_detail": {},
+        "expected_tool_call_total_count": 99,
+        "tool_calls_schema_validation_error_count": 3,
+        "tool_calls_successful_count": 81,
+        "tool_calls_total_count": 167,
+        "tool_calls_count_distribution": {
+          "2": 11,
+          "1": 46,
+          "3": 18,
+          "4": 5,
+          "5": 3,
+          "9": 1
+        },
+        "error_only_reasoning_checked_count": 101,
+        "error_only_reasoning_count": 0,
+        "error_only_reasoning_rate": 0.0,
+        "success_rate": 1.0,
+        "tool_calls_accuracy": 0.9703
+      },
+      "output_file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.5_retry_20260401_200428/loop_09/MiniMax-M2.5/MiniMax-M2.5_results.jsonl",
+      "summary_file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.5_retry_20260401_200428/loop_09/MiniMax-M2.5/MiniMax-M2.5_summary.json",
+      "completed_at": "2026-04-01T20:32:57.011219"
+    }
+  ],
+  "generated_at": "2026-04-01T20:32:57.017166"
+}

--- a/output-dir/MiniMax-M2.5/loop_10/MiniMax-M2.5/MiniMax-M2.5_summary.json
+++ b/output-dir/MiniMax-M2.5/loop_10/MiniMax-M2.5/MiniMax-M2.5_summary.json
@@ -1,0 +1,32 @@
+{
+    "model": "minimax-m2.5",
+    "success_count": 101,
+    "failure_count": 0,
+    "all_count": 101,
+    "tool_calls_finish_tool_calls": 84,
+    "tool_calls_finish_stop": 0,
+    "stop_finish_tool_calls": 0,
+    "stop_finish_stop": 15,
+    "tool_calls_finish_others": 0,
+    "tool_calls_finish_others_detail": {},
+    "expected_tool_call_total_count": 99,
+    "tool_calls_schema_validation_error_count": 4,
+    "tool_calls_successful_count": 80,
+    "tool_calls_total_count": 165,
+    "tool_calls_count_distribution": {
+        "1": 48,
+        "2": 10,
+        "3": 15,
+        "4": 7,
+        "5": 3,
+        "9": 1
+    },
+    "language_following_checked_count": 2,
+    "language_following_valid_count": 1,
+    "language_following_invalid_count": 1,
+    "error_only_reasoning_checked_count": 101,
+    "error_only_reasoning_count": 0,
+    "error_only_reasoning_rate": 0.0,
+    "success_rate": 1.0,
+    "tool_calls_accuracy": 0.9802
+}

--- a/output-dir/MiniMax-M2.5/loop_10/MiniMax-M2.5/batch_report.json
+++ b/output-dir/MiniMax-M2.5/loop_10/MiniMax-M2.5/batch_report.json
@@ -1,0 +1,48 @@
+{
+  "test_file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.5_retry_20260401_200428/loop_10/MiniMax-M2.5/test_data.jsonl",
+  "total_providers": 1,
+  "successful_providers": 1,
+  "failed_providers": 0,
+  "provider_results": [
+    {
+      "provider": "MiniMax-M2.5",
+      "status": "success",
+      "summary": {
+        "model": "minimax-m2.5",
+        "success_count": 101,
+        "failure_count": 0,
+        "all_count": 101,
+        "tool_calls_finish_tool_calls": 84,
+        "tool_calls_finish_stop": 0,
+        "stop_finish_tool_calls": 0,
+        "stop_finish_stop": 15,
+        "tool_calls_finish_others": 0,
+        "tool_calls_finish_others_detail": {},
+        "expected_tool_call_total_count": 99,
+        "tool_calls_schema_validation_error_count": 4,
+        "tool_calls_successful_count": 80,
+        "tool_calls_total_count": 165,
+        "tool_calls_count_distribution": {
+          "1": 48,
+          "2": 10,
+          "3": 15,
+          "4": 7,
+          "5": 3,
+          "9": 1
+        },
+        "language_following_checked_count": 2,
+        "language_following_valid_count": 1,
+        "language_following_invalid_count": 1,
+        "error_only_reasoning_checked_count": 101,
+        "error_only_reasoning_count": 0,
+        "error_only_reasoning_rate": 0.0,
+        "success_rate": 1.0,
+        "tool_calls_accuracy": 0.9802
+      },
+      "output_file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.5_retry_20260401_200428/loop_10/MiniMax-M2.5/MiniMax-M2.5_results.jsonl",
+      "summary_file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.5_retry_20260401_200428/loop_10/MiniMax-M2.5/MiniMax-M2.5_summary.json",
+      "completed_at": "2026-04-01T20:35:19.110982"
+    }
+  ],
+  "generated_at": "2026-04-01T20:35:19.119211"
+}

--- a/output-dir/MiniMax-M2.5/metrics_report.json
+++ b/output-dir/MiniMax-M2.5/metrics_report.json
@@ -1,0 +1,124 @@
+{
+    "summary": {
+        "total_files": 10,
+        "average_metrics": {
+            "1. Query-Success-Rate": 1.0,
+            "2. ToolCalls-Match-Rate": 0.9919191919191919,
+            "4. ToolCalls-Accuracy": 0.9630952380952381,
+            "5. Response-Success-Rate-Not-Only-Reasoning": 1.0,
+            "6. Language-Following-Success-Rate": 0.8
+        }
+    },
+    "results": [
+        {
+            "file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.5_retry_20260401_200428/loop_01/MiniMax-M2.5/MiniMax-M2.5_summary.json",
+            "model": "minimax-m2.5",
+            "metrics": {
+                "1. Query-Success-Rate": 1.0,
+                "2. ToolCalls-Match-Rate": 0.98989898989899,
+                "4. ToolCalls-Accuracy": 0.9761904761904762,
+                "5. Response-Success-Rate-Not-Only-Reasoning": 1.0,
+                "6. Language-Following-Success-Rate": 1.0
+            }
+        },
+        {
+            "file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.5_retry_20260401_200428/loop_02/MiniMax-M2.5/MiniMax-M2.5_summary.json",
+            "model": "minimax-m2.5",
+            "metrics": {
+                "1. Query-Success-Rate": 1.0,
+                "2. ToolCalls-Match-Rate": 1.0,
+                "4. ToolCalls-Accuracy": 0.9880952380952381,
+                "5. Response-Success-Rate-Not-Only-Reasoning": 1.0,
+                "6. Language-Following-Success-Rate": 0.5
+            }
+        },
+        {
+            "file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.5_retry_20260401_200428/loop_03/MiniMax-M2.5/MiniMax-M2.5_summary.json",
+            "model": "minimax-m2.5",
+            "metrics": {
+                "1. Query-Success-Rate": 1.0,
+                "2. ToolCalls-Match-Rate": 0.9595959595959596,
+                "4. ToolCalls-Accuracy": 0.9642857142857143,
+                "5. Response-Success-Rate-Not-Only-Reasoning": 1.0,
+                "6. Language-Following-Success-Rate": 1.0
+            }
+        },
+        {
+            "file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.5_retry_20260401_200428/loop_04/MiniMax-M2.5/MiniMax-M2.5_summary.json",
+            "model": "minimax-m2.5",
+            "metrics": {
+                "1. Query-Success-Rate": 1.0,
+                "2. ToolCalls-Match-Rate": 1.0,
+                "4. ToolCalls-Accuracy": 0.9523809523809523,
+                "5. Response-Success-Rate-Not-Only-Reasoning": 1.0,
+                "6. Language-Following-Success-Rate": 1.0
+            }
+        },
+        {
+            "file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.5_retry_20260401_200428/loop_05/MiniMax-M2.5/MiniMax-M2.5_summary.json",
+            "model": "minimax-m2.5",
+            "metrics": {
+                "1. Query-Success-Rate": 1.0,
+                "2. ToolCalls-Match-Rate": 1.0,
+                "4. ToolCalls-Accuracy": 0.9642857142857143,
+                "5. Response-Success-Rate-Not-Only-Reasoning": 1.0,
+                "6. Language-Following-Success-Rate": 0.5
+            }
+        },
+        {
+            "file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.5_retry_20260401_200428/loop_06/MiniMax-M2.5/MiniMax-M2.5_summary.json",
+            "model": "minimax-m2.5",
+            "metrics": {
+                "1. Query-Success-Rate": 1.0,
+                "2. ToolCalls-Match-Rate": 0.98989898989899,
+                "4. ToolCalls-Accuracy": 0.9523809523809523,
+                "5. Response-Success-Rate-Not-Only-Reasoning": 1.0,
+                "6. Language-Following-Success-Rate": 1.0
+            }
+        },
+        {
+            "file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.5_retry_20260401_200428/loop_07/MiniMax-M2.5/MiniMax-M2.5_summary.json",
+            "model": "minimax-m2.5",
+            "metrics": {
+                "1. Query-Success-Rate": 1.0,
+                "2. ToolCalls-Match-Rate": 1.0,
+                "4. ToolCalls-Accuracy": 0.9404761904761905,
+                "5. Response-Success-Rate-Not-Only-Reasoning": 1.0,
+                "6. Language-Following-Success-Rate": 1.0
+            }
+        },
+        {
+            "file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.5_retry_20260401_200428/loop_08/MiniMax-M2.5/MiniMax-M2.5_summary.json",
+            "model": "minimax-m2.5",
+            "metrics": {
+                "1. Query-Success-Rate": 1.0,
+                "2. ToolCalls-Match-Rate": 0.98989898989899,
+                "4. ToolCalls-Accuracy": 0.9761904761904762,
+                "5. Response-Success-Rate-Not-Only-Reasoning": 1.0,
+                "6. Language-Following-Success-Rate": 1.0
+            }
+        },
+        {
+            "file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.5_retry_20260401_200428/loop_09/MiniMax-M2.5/MiniMax-M2.5_summary.json",
+            "model": "minimax-m2.5",
+            "metrics": {
+                "1. Query-Success-Rate": 1.0,
+                "2. ToolCalls-Match-Rate": 0.98989898989899,
+                "4. ToolCalls-Accuracy": 0.9642857142857143,
+                "5. Response-Success-Rate-Not-Only-Reasoning": 1.0,
+                "6. Language-Following-Success-Rate": 0.5
+            }
+        },
+        {
+            "file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.5_retry_20260401_200428/loop_10/MiniMax-M2.5/MiniMax-M2.5_summary.json",
+            "model": "minimax-m2.5",
+            "metrics": {
+                "1. Query-Success-Rate": 1.0,
+                "2. ToolCalls-Match-Rate": 1.0,
+                "4. ToolCalls-Accuracy": 0.9523809523809523,
+                "5. Response-Success-Rate-Not-Only-Reasoning": 1.0,
+                "6. Language-Following-Success-Rate": 0.5
+            }
+        }
+    ]
+}

--- a/output-dir/MiniMax-M2.5/monitor.log
+++ b/output-dir/MiniMax-M2.5/monitor.log
@@ -1,0 +1,307 @@
+[2026-04-01 20:04:28] ========== Starting minimax-m2.5 batch test ==========
+[2026-04-01 20:04:28] Target: 10 clean loops, max_workers=50
+[2026-04-01 20:04:28] Output: /Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.5_retry_20260401_200428
+[2026-04-01 20:04:28] --- Loop 01 (clean=0/10) starting ---
+[2026-04-01 20:08:24] OK: Loop 01 clean (success=101, failure=0) [1/10]
+[2026-04-01 20:08:25] --- Loop 02 (clean=1/10) starting ---
+[2026-04-01 20:17:59] OK: Loop 02 clean (success=101, failure=0) [2/10]
+[2026-04-01 20:17:59] --- Loop 03 (clean=2/10) starting ---
+[2026-04-01 20:20:14] OK: Loop 03 clean (success=101, failure=0) [3/10]
+[2026-04-01 20:20:14] --- Loop 04 (clean=3/10) starting ---
+[2026-04-01 20:22:25] OK: Loop 04 clean (success=101, failure=0) [4/10]
+[2026-04-01 20:22:25] --- Loop 05 (clean=4/10) starting ---
+[2026-04-01 20:24:38] OK: Loop 05 clean (success=101, failure=0) [5/10]
+[2026-04-01 20:24:38] --- Loop 06 (clean=5/10) starting ---
+[2026-04-01 20:26:29] OK: Loop 06 clean (success=101, failure=0) [6/10]
+[2026-04-01 20:26:29] --- Loop 07 (clean=6/10) starting ---
+[2026-04-01 20:28:26] OK: Loop 07 clean (success=101, failure=0) [7/10]
+[2026-04-01 20:28:26] --- Loop 08 (clean=7/10) starting ---
+[2026-04-01 20:30:09] OK: Loop 08 clean (success=101, failure=0) [8/10]
+[2026-04-01 20:30:09] --- Loop 09 (clean=8/10) starting ---
+[2026-04-01 20:32:57] OK: Loop 09 clean (success=101, failure=0) [9/10]
+[2026-04-01 20:32:57] --- Loop 10 (clean=9/10) starting ---
+[2026-04-01 20:35:19] OK: Loop 10 clean (success=101, failure=0) [10/10]
+[2026-04-01 20:35:19] ========== DONE: minimax-m2.5 ==========
+[2026-04-01 20:35:19] Collected 10 clean loops in 10 total runs
+[2026-04-01 20:35:19] Failed loops: none
+[2026-04-01 20:35:19] Collecting metrics...
+Read expected_tool_call statistics from /Users/minimax/GitHub/MiniMax-Provider-Verifier/sample.jsonl:
+  - expected_tool_call=True: 84
+  - expected_tool_call=False: 15
+  - Total (Match-Rate denominator): 99
+Searching directory: /Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.5_retry_20260401_200428
+Specified provider: MiniMax-M2.5
+
+Total 10 files found
+
+Files found:
+  1. /Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.5_retry_20260401_200428/loop_01/MiniMax-M2.5/MiniMax-M2.5_summary.json
+  2. /Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.5_retry_20260401_200428/loop_02/MiniMax-M2.5/MiniMax-M2.5_summary.json
+  3. /Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.5_retry_20260401_200428/loop_03/MiniMax-M2.5/MiniMax-M2.5_summary.json
+  4. /Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.5_retry_20260401_200428/loop_04/MiniMax-M2.5/MiniMax-M2.5_summary.json
+  5. /Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.5_retry_20260401_200428/loop_05/MiniMax-M2.5/MiniMax-M2.5_summary.json
+  6. /Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.5_retry_20260401_200428/loop_06/MiniMax-M2.5/MiniMax-M2.5_summary.json
+  7. /Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.5_retry_20260401_200428/loop_07/MiniMax-M2.5/MiniMax-M2.5_summary.json
+  8. /Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.5_retry_20260401_200428/loop_08/MiniMax-M2.5/MiniMax-M2.5_summary.json
+  9. /Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.5_retry_20260401_200428/loop_09/MiniMax-M2.5/MiniMax-M2.5_summary.json
+  10. /Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.5_retry_20260401_200428/loop_10/MiniMax-M2.5/MiniMax-M2.5_summary.json
+Warning: Reference folder does not exist: /Users/minimax/GitHub/MiniMax-Provider-Verifier/MiniMax-M2.5
+
+================================================================================
+File: /Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.5_retry_20260401_200428/loop_01/MiniMax-M2.5/MiniMax-M2.5_summary.json
+Model: minimax-m2.5
+--------------------------------------------------------------------------------
+Raw Data:
+  - Total queries (all_count): 101
+  - Success count (success_count): 101
+  - Failure count (failure_count): 0
+  - ToolCalls finish count (tool_calls_finish_tool_calls): 84
+  - ToolCalls success count (tool_calls_successful_count): 82
+  - Only reasoning error checked (error_only_reasoning_checked_count): 101
+  - Only reasoning error count (error_only_reasoning_count): 0
+  - Language following checked (language_following_checked_count): 2
+  - Language following valid (language_following_valid_count): 2
+--------------------------------------------------------------------------------
+Calculated Metrics:
+  1. Query-Success-Rate: 1.0000 (100.00%)
+  2. ToolCalls-Match-Rate: 0.9899 (98.99%)
+  4. ToolCalls-Accuracy: 0.9762 (97.62%)
+  5. Response-Success-Rate-Not-Only-Reasoning: 1.0000 (100.00%)
+  6. Language-Following-Success-Rate: 1.0000 (100.00%)
+================================================================================
+
+================================================================================
+File: /Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.5_retry_20260401_200428/loop_02/MiniMax-M2.5/MiniMax-M2.5_summary.json
+Model: minimax-m2.5
+--------------------------------------------------------------------------------
+Raw Data:
+  - Total queries (all_count): 101
+  - Success count (success_count): 101
+  - Failure count (failure_count): 0
+  - ToolCalls finish count (tool_calls_finish_tool_calls): 84
+  - ToolCalls success count (tool_calls_successful_count): 83
+  - Only reasoning error checked (error_only_reasoning_checked_count): 101
+  - Only reasoning error count (error_only_reasoning_count): 0
+  - Language following checked (language_following_checked_count): 2
+  - Language following valid (language_following_valid_count): 1
+--------------------------------------------------------------------------------
+Calculated Metrics:
+  1. Query-Success-Rate: 1.0000 (100.00%)
+  2. ToolCalls-Match-Rate: 1.0000 (100.00%)
+  4. ToolCalls-Accuracy: 0.9881 (98.81%)
+  5. Response-Success-Rate-Not-Only-Reasoning: 1.0000 (100.00%)
+  6. Language-Following-Success-Rate: 0.5000 (50.00%)
+================================================================================
+
+================================================================================
+File: /Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.5_retry_20260401_200428/loop_03/MiniMax-M2.5/MiniMax-M2.5_summary.json
+Model: minimax-m2.5
+--------------------------------------------------------------------------------
+Raw Data:
+  - Total queries (all_count): 101
+  - Success count (success_count): 101
+  - Failure count (failure_count): 0
+  - ToolCalls finish count (tool_calls_finish_tool_calls): 84
+  - ToolCalls success count (tool_calls_successful_count): 81
+  - Only reasoning error checked (error_only_reasoning_checked_count): 101
+  - Only reasoning error count (error_only_reasoning_count): 0
+  - Language following checked (language_following_checked_count): 2
+  - Language following valid (language_following_valid_count): 2
+--------------------------------------------------------------------------------
+Calculated Metrics:
+  1. Query-Success-Rate: 1.0000 (100.00%)
+  2. ToolCalls-Match-Rate: 0.9596 (95.96%)
+  4. ToolCalls-Accuracy: 0.9643 (96.43%)
+  5. Response-Success-Rate-Not-Only-Reasoning: 1.0000 (100.00%)
+  6. Language-Following-Success-Rate: 1.0000 (100.00%)
+================================================================================
+
+================================================================================
+File: /Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.5_retry_20260401_200428/loop_04/MiniMax-M2.5/MiniMax-M2.5_summary.json
+Model: minimax-m2.5
+--------------------------------------------------------------------------------
+Raw Data:
+  - Total queries (all_count): 101
+  - Success count (success_count): 101
+  - Failure count (failure_count): 0
+  - ToolCalls finish count (tool_calls_finish_tool_calls): 84
+  - ToolCalls success count (tool_calls_successful_count): 80
+  - Only reasoning error checked (error_only_reasoning_checked_count): 101
+  - Only reasoning error count (error_only_reasoning_count): 0
+  - Language following checked (language_following_checked_count): 2
+  - Language following valid (language_following_valid_count): 2
+--------------------------------------------------------------------------------
+Calculated Metrics:
+  1. Query-Success-Rate: 1.0000 (100.00%)
+  2. ToolCalls-Match-Rate: 1.0000 (100.00%)
+  4. ToolCalls-Accuracy: 0.9524 (95.24%)
+  5. Response-Success-Rate-Not-Only-Reasoning: 1.0000 (100.00%)
+  6. Language-Following-Success-Rate: 1.0000 (100.00%)
+================================================================================
+
+================================================================================
+File: /Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.5_retry_20260401_200428/loop_05/MiniMax-M2.5/MiniMax-M2.5_summary.json
+Model: minimax-m2.5
+--------------------------------------------------------------------------------
+Raw Data:
+  - Total queries (all_count): 101
+  - Success count (success_count): 101
+  - Failure count (failure_count): 0
+  - ToolCalls finish count (tool_calls_finish_tool_calls): 84
+  - ToolCalls success count (tool_calls_successful_count): 81
+  - Only reasoning error checked (error_only_reasoning_checked_count): 101
+  - Only reasoning error count (error_only_reasoning_count): 0
+  - Language following checked (language_following_checked_count): 2
+  - Language following valid (language_following_valid_count): 1
+--------------------------------------------------------------------------------
+Calculated Metrics:
+  1. Query-Success-Rate: 1.0000 (100.00%)
+  2. ToolCalls-Match-Rate: 1.0000 (100.00%)
+  4. ToolCalls-Accuracy: 0.9643 (96.43%)
+  5. Response-Success-Rate-Not-Only-Reasoning: 1.0000 (100.00%)
+  6. Language-Following-Success-Rate: 0.5000 (50.00%)
+================================================================================
+
+================================================================================
+File: /Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.5_retry_20260401_200428/loop_06/MiniMax-M2.5/MiniMax-M2.5_summary.json
+Model: minimax-m2.5
+--------------------------------------------------------------------------------
+Raw Data:
+  - Total queries (all_count): 101
+  - Success count (success_count): 101
+  - Failure count (failure_count): 0
+  - ToolCalls finish count (tool_calls_finish_tool_calls): 84
+  - ToolCalls success count (tool_calls_successful_count): 80
+  - Only reasoning error checked (error_only_reasoning_checked_count): 101
+  - Only reasoning error count (error_only_reasoning_count): 0
+  - Language following checked (language_following_checked_count): 2
+  - Language following valid (language_following_valid_count): 2
+--------------------------------------------------------------------------------
+Calculated Metrics:
+  1. Query-Success-Rate: 1.0000 (100.00%)
+  2. ToolCalls-Match-Rate: 0.9899 (98.99%)
+  4. ToolCalls-Accuracy: 0.9524 (95.24%)
+  5. Response-Success-Rate-Not-Only-Reasoning: 1.0000 (100.00%)
+  6. Language-Following-Success-Rate: 1.0000 (100.00%)
+================================================================================
+
+================================================================================
+File: /Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.5_retry_20260401_200428/loop_07/MiniMax-M2.5/MiniMax-M2.5_summary.json
+Model: minimax-m2.5
+--------------------------------------------------------------------------------
+Raw Data:
+  - Total queries (all_count): 101
+  - Success count (success_count): 101
+  - Failure count (failure_count): 0
+  - ToolCalls finish count (tool_calls_finish_tool_calls): 84
+  - ToolCalls success count (tool_calls_successful_count): 79
+  - Only reasoning error checked (error_only_reasoning_checked_count): 101
+  - Only reasoning error count (error_only_reasoning_count): 0
+  - Language following checked (language_following_checked_count): 2
+  - Language following valid (language_following_valid_count): 2
+--------------------------------------------------------------------------------
+Calculated Metrics:
+  1. Query-Success-Rate: 1.0000 (100.00%)
+  2. ToolCalls-Match-Rate: 1.0000 (100.00%)
+  4. ToolCalls-Accuracy: 0.9405 (94.05%)
+  5. Response-Success-Rate-Not-Only-Reasoning: 1.0000 (100.00%)
+  6. Language-Following-Success-Rate: 1.0000 (100.00%)
+================================================================================
+
+================================================================================
+File: /Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.5_retry_20260401_200428/loop_08/MiniMax-M2.5/MiniMax-M2.5_summary.json
+Model: minimax-m2.5
+--------------------------------------------------------------------------------
+Raw Data:
+  - Total queries (all_count): 101
+  - Success count (success_count): 101
+  - Failure count (failure_count): 0
+  - ToolCalls finish count (tool_calls_finish_tool_calls): 84
+  - ToolCalls success count (tool_calls_successful_count): 82
+  - Only reasoning error checked (error_only_reasoning_checked_count): 101
+  - Only reasoning error count (error_only_reasoning_count): 0
+  - Language following checked (language_following_checked_count): 2
+  - Language following valid (language_following_valid_count): 2
+--------------------------------------------------------------------------------
+Calculated Metrics:
+  1. Query-Success-Rate: 1.0000 (100.00%)
+  2. ToolCalls-Match-Rate: 0.9899 (98.99%)
+  4. ToolCalls-Accuracy: 0.9762 (97.62%)
+  5. Response-Success-Rate-Not-Only-Reasoning: 1.0000 (100.00%)
+  6. Language-Following-Success-Rate: 1.0000 (100.00%)
+================================================================================
+
+================================================================================
+File: /Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.5_retry_20260401_200428/loop_09/MiniMax-M2.5/MiniMax-M2.5_summary.json
+Model: minimax-m2.5
+--------------------------------------------------------------------------------
+Raw Data:
+  - Total queries (all_count): 101
+  - Success count (success_count): 101
+  - Failure count (failure_count): 0
+  - ToolCalls finish count (tool_calls_finish_tool_calls): 84
+  - ToolCalls success count (tool_calls_successful_count): 81
+  - Only reasoning error checked (error_only_reasoning_checked_count): 101
+  - Only reasoning error count (error_only_reasoning_count): 0
+  - Language following checked (language_following_checked_count): 2
+  - Language following valid (language_following_valid_count): 1
+--------------------------------------------------------------------------------
+Calculated Metrics:
+  1. Query-Success-Rate: 1.0000 (100.00%)
+  2. ToolCalls-Match-Rate: 0.9899 (98.99%)
+  4. ToolCalls-Accuracy: 0.9643 (96.43%)
+  5. Response-Success-Rate-Not-Only-Reasoning: 1.0000 (100.00%)
+  6. Language-Following-Success-Rate: 0.5000 (50.00%)
+================================================================================
+
+================================================================================
+File: /Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.5_retry_20260401_200428/loop_10/MiniMax-M2.5/MiniMax-M2.5_summary.json
+Model: minimax-m2.5
+--------------------------------------------------------------------------------
+Raw Data:
+  - Total queries (all_count): 101
+  - Success count (success_count): 101
+  - Failure count (failure_count): 0
+  - ToolCalls finish count (tool_calls_finish_tool_calls): 84
+  - ToolCalls success count (tool_calls_successful_count): 80
+  - Only reasoning error checked (error_only_reasoning_checked_count): 101
+  - Only reasoning error count (error_only_reasoning_count): 0
+  - Language following checked (language_following_checked_count): 2
+  - Language following valid (language_following_valid_count): 1
+--------------------------------------------------------------------------------
+Calculated Metrics:
+  1. Query-Success-Rate: 1.0000 (100.00%)
+  2. ToolCalls-Match-Rate: 1.0000 (100.00%)
+  4. ToolCalls-Accuracy: 0.9524 (95.24%)
+  5. Response-Success-Rate-Not-Only-Reasoning: 1.0000 (100.00%)
+  6. Language-Following-Success-Rate: 0.5000 (50.00%)
+================================================================================
+
+
+========================================================================================================================
+Summary Table
+========================================================================================================================
+
+File                                     Model                          Q-Succ     TC-Match   Tool-Acc   R-Succ     Lang-Succ 
+----------------------------------------------------------------------------------------------------
+MiniMax-M2.5_summary.json                minimax-m2.5                     100.00%    98.99%    97.62%   100.00%   100.00%
+MiniMax-M2.5_summary.json                minimax-m2.5                     100.00%   100.00%    98.81%   100.00%    50.00%
+MiniMax-M2.5_summary.json                minimax-m2.5                     100.00%    95.96%    96.43%   100.00%   100.00%
+MiniMax-M2.5_summary.json                minimax-m2.5                     100.00%   100.00%    95.24%   100.00%   100.00%
+MiniMax-M2.5_summary.json                minimax-m2.5                     100.00%   100.00%    96.43%   100.00%    50.00%
+MiniMax-M2.5_summary.json                minimax-m2.5                     100.00%    98.99%    95.24%   100.00%   100.00%
+MiniMax-M2.5_summary.json                minimax-m2.5                     100.00%   100.00%    94.05%   100.00%   100.00%
+MiniMax-M2.5_summary.json                minimax-m2.5                     100.00%    98.99%    97.62%   100.00%   100.00%
+MiniMax-M2.5_summary.json                minimax-m2.5                     100.00%    98.99%    96.43%   100.00%    50.00%
+MiniMax-M2.5_summary.json                minimax-m2.5                     100.00%   100.00%    95.24%   100.00%    50.00%
+====================================================================================================
+
+Averages:
+  1. Query-Success-Rate: 1.0000 (100.00%)
+  2. ToolCalls-Match-Rate: 0.9919 (99.19%)
+  4. ToolCalls-Accuracy: 0.9631 (96.31%)
+  5. Response-Success-Rate-Not-Only-Reasoning: 1.0000 (100.00%)
+  6. Language-Following-Success-Rate: 0.8000 (80.00%)
+
+Results saved to: /Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.5_retry_20260401_200428/metrics_report.json
+[2026-04-01 20:35:21] Results: /Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.5_retry_20260401_200428

--- a/output-dir/MiniMax-M2.5/status.json
+++ b/output-dir/MiniMax-M2.5/status.json
@@ -1,0 +1,49 @@
+{
+  "model": "minimax-m2.5",
+  "target": 10,
+  "clean": 10,
+  "total_runs": 10,
+  "failed_loops": [],
+  "clean_loops": [
+    {
+      "loop": "01",
+      "success_count": 101
+    },
+    {
+      "loop": "02",
+      "success_count": 101
+    },
+    {
+      "loop": "03",
+      "success_count": 101
+    },
+    {
+      "loop": "04",
+      "success_count": 101
+    },
+    {
+      "loop": "05",
+      "success_count": 101
+    },
+    {
+      "loop": "06",
+      "success_count": 101
+    },
+    {
+      "loop": "07",
+      "success_count": 101
+    },
+    {
+      "loop": "08",
+      "success_count": 101
+    },
+    {
+      "loop": "09",
+      "success_count": 101
+    },
+    {
+      "loop": "10",
+      "success_count": 101
+    }
+  ]
+}

--- a/output-dir/MiniMax-M2.7/loop_01/MiniMax-M2.7/MiniMax-M2.7_summary.json
+++ b/output-dir/MiniMax-M2.7/loop_01/MiniMax-M2.7/MiniMax-M2.7_summary.json
@@ -1,0 +1,33 @@
+{
+    "model": "minimax-m2.7",
+    "success_count": 101,
+    "failure_count": 0,
+    "all_count": 101,
+    "tool_calls_finish_tool_calls": 84,
+    "tool_calls_finish_stop": 0,
+    "stop_finish_tool_calls": 1,
+    "stop_finish_stop": 14,
+    "tool_calls_finish_others": 0,
+    "tool_calls_finish_others_detail": {},
+    "expected_tool_call_total_count": 99,
+    "tool_calls_schema_validation_error_count": 1,
+    "tool_calls_successful_count": 83,
+    "tool_calls_total_count": 173,
+    "tool_calls_count_distribution": {
+        "2": 14,
+        "1": 43,
+        "3": 18,
+        "5": 2,
+        "4": 5,
+        "8": 1,
+        "9": 1
+    },
+    "language_following_checked_count": 2,
+    "language_following_valid_count": 2,
+    "language_following_invalid_count": 0,
+    "error_only_reasoning_checked_count": 101,
+    "error_only_reasoning_count": 0,
+    "error_only_reasoning_rate": 0.0,
+    "success_rate": 1.0,
+    "tool_calls_accuracy": 0.9703
+}

--- a/output-dir/MiniMax-M2.7/loop_01/MiniMax-M2.7/batch_report.json
+++ b/output-dir/MiniMax-M2.7/loop_01/MiniMax-M2.7/batch_report.json
@@ -1,0 +1,49 @@
+{
+  "test_file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.7_retry_20260401_200428/loop_01/MiniMax-M2.7/test_data.jsonl",
+  "total_providers": 1,
+  "successful_providers": 1,
+  "failed_providers": 0,
+  "provider_results": [
+    {
+      "provider": "MiniMax-M2.7",
+      "status": "success",
+      "summary": {
+        "model": "minimax-m2.7",
+        "success_count": 101,
+        "failure_count": 0,
+        "all_count": 101,
+        "tool_calls_finish_tool_calls": 84,
+        "tool_calls_finish_stop": 0,
+        "stop_finish_tool_calls": 1,
+        "stop_finish_stop": 14,
+        "tool_calls_finish_others": 0,
+        "tool_calls_finish_others_detail": {},
+        "expected_tool_call_total_count": 99,
+        "tool_calls_schema_validation_error_count": 1,
+        "tool_calls_successful_count": 83,
+        "tool_calls_total_count": 173,
+        "tool_calls_count_distribution": {
+          "2": 14,
+          "1": 43,
+          "3": 18,
+          "5": 2,
+          "4": 5,
+          "8": 1,
+          "9": 1
+        },
+        "language_following_checked_count": 2,
+        "language_following_valid_count": 2,
+        "language_following_invalid_count": 0,
+        "error_only_reasoning_checked_count": 101,
+        "error_only_reasoning_count": 0,
+        "error_only_reasoning_rate": 0.0,
+        "success_rate": 1.0,
+        "tool_calls_accuracy": 0.9703
+      },
+      "output_file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.7_retry_20260401_200428/loop_01/MiniMax-M2.7/MiniMax-M2.7_results.jsonl",
+      "summary_file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.7_retry_20260401_200428/loop_01/MiniMax-M2.7/MiniMax-M2.7_summary.json",
+      "completed_at": "2026-04-01T20:06:58.160485"
+    }
+  ],
+  "generated_at": "2026-04-01T20:06:58.171876"
+}

--- a/output-dir/MiniMax-M2.7/loop_02/MiniMax-M2.7/MiniMax-M2.7_summary.json
+++ b/output-dir/MiniMax-M2.7/loop_02/MiniMax-M2.7/MiniMax-M2.7_summary.json
@@ -1,0 +1,33 @@
+{
+    "model": "minimax-m2.7",
+    "success_count": 101,
+    "failure_count": 0,
+    "all_count": 101,
+    "tool_calls_finish_tool_calls": 84,
+    "tool_calls_finish_stop": 0,
+    "stop_finish_tool_calls": 1,
+    "stop_finish_stop": 14,
+    "tool_calls_finish_others": 0,
+    "tool_calls_finish_others_detail": {},
+    "expected_tool_call_total_count": 99,
+    "tool_calls_schema_validation_error_count": 3,
+    "tool_calls_successful_count": 81,
+    "tool_calls_total_count": 172,
+    "tool_calls_count_distribution": {
+        "2": 13,
+        "1": 45,
+        "3": 16,
+        "5": 3,
+        "4": 5,
+        "8": 1,
+        "9": 1
+    },
+    "language_following_checked_count": 2,
+    "language_following_valid_count": 1,
+    "language_following_invalid_count": 1,
+    "error_only_reasoning_checked_count": 101,
+    "error_only_reasoning_count": 0,
+    "error_only_reasoning_rate": 0.0,
+    "success_rate": 1.0,
+    "tool_calls_accuracy": 0.9703
+}

--- a/output-dir/MiniMax-M2.7/loop_02/MiniMax-M2.7/batch_report.json
+++ b/output-dir/MiniMax-M2.7/loop_02/MiniMax-M2.7/batch_report.json
@@ -1,0 +1,49 @@
+{
+  "test_file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.7_retry_20260401_200428/loop_02/MiniMax-M2.7/test_data.jsonl",
+  "total_providers": 1,
+  "successful_providers": 1,
+  "failed_providers": 0,
+  "provider_results": [
+    {
+      "provider": "MiniMax-M2.7",
+      "status": "success",
+      "summary": {
+        "model": "minimax-m2.7",
+        "success_count": 101,
+        "failure_count": 0,
+        "all_count": 101,
+        "tool_calls_finish_tool_calls": 84,
+        "tool_calls_finish_stop": 0,
+        "stop_finish_tool_calls": 1,
+        "stop_finish_stop": 14,
+        "tool_calls_finish_others": 0,
+        "tool_calls_finish_others_detail": {},
+        "expected_tool_call_total_count": 99,
+        "tool_calls_schema_validation_error_count": 3,
+        "tool_calls_successful_count": 81,
+        "tool_calls_total_count": 172,
+        "tool_calls_count_distribution": {
+          "2": 13,
+          "1": 45,
+          "3": 16,
+          "5": 3,
+          "4": 5,
+          "8": 1,
+          "9": 1
+        },
+        "language_following_checked_count": 2,
+        "language_following_valid_count": 1,
+        "language_following_invalid_count": 1,
+        "error_only_reasoning_checked_count": 101,
+        "error_only_reasoning_count": 0,
+        "error_only_reasoning_rate": 0.0,
+        "success_rate": 1.0,
+        "tool_calls_accuracy": 0.9703
+      },
+      "output_file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.7_retry_20260401_200428/loop_02/MiniMax-M2.7/MiniMax-M2.7_results.jsonl",
+      "summary_file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.7_retry_20260401_200428/loop_02/MiniMax-M2.7/MiniMax-M2.7_summary.json",
+      "completed_at": "2026-04-01T20:09:21.704874"
+    }
+  ],
+  "generated_at": "2026-04-01T20:09:21.717031"
+}

--- a/output-dir/MiniMax-M2.7/loop_03/MiniMax-M2.7/MiniMax-M2.7_summary.json
+++ b/output-dir/MiniMax-M2.7/loop_03/MiniMax-M2.7/MiniMax-M2.7_summary.json
@@ -1,0 +1,32 @@
+{
+    "model": "minimax-m2.7",
+    "success_count": 101,
+    "failure_count": 0,
+    "all_count": 101,
+    "language_following_checked_count": 2,
+    "language_following_valid_count": 2,
+    "language_following_invalid_count": 0,
+    "tool_calls_finish_tool_calls": 84,
+    "tool_calls_finish_stop": 0,
+    "stop_finish_tool_calls": 0,
+    "stop_finish_stop": 15,
+    "tool_calls_finish_others": 0,
+    "tool_calls_finish_others_detail": {},
+    "expected_tool_call_total_count": 99,
+    "tool_calls_schema_validation_error_count": 2,
+    "tool_calls_successful_count": 82,
+    "tool_calls_total_count": 162,
+    "tool_calls_count_distribution": {
+        "2": 16,
+        "1": 45,
+        "3": 15,
+        "4": 4,
+        "5": 3,
+        "9": 1
+    },
+    "error_only_reasoning_checked_count": 101,
+    "error_only_reasoning_count": 0,
+    "error_only_reasoning_rate": 0.0,
+    "success_rate": 1.0,
+    "tool_calls_accuracy": 0.9802
+}

--- a/output-dir/MiniMax-M2.7/loop_03/MiniMax-M2.7/batch_report.json
+++ b/output-dir/MiniMax-M2.7/loop_03/MiniMax-M2.7/batch_report.json
@@ -1,0 +1,48 @@
+{
+  "test_file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.7_retry_20260401_200428/loop_03/MiniMax-M2.7/test_data.jsonl",
+  "total_providers": 1,
+  "successful_providers": 1,
+  "failed_providers": 0,
+  "provider_results": [
+    {
+      "provider": "MiniMax-M2.7",
+      "status": "success",
+      "summary": {
+        "model": "minimax-m2.7",
+        "success_count": 101,
+        "failure_count": 0,
+        "all_count": 101,
+        "language_following_checked_count": 2,
+        "language_following_valid_count": 2,
+        "language_following_invalid_count": 0,
+        "tool_calls_finish_tool_calls": 84,
+        "tool_calls_finish_stop": 0,
+        "stop_finish_tool_calls": 0,
+        "stop_finish_stop": 15,
+        "tool_calls_finish_others": 0,
+        "tool_calls_finish_others_detail": {},
+        "expected_tool_call_total_count": 99,
+        "tool_calls_schema_validation_error_count": 2,
+        "tool_calls_successful_count": 82,
+        "tool_calls_total_count": 162,
+        "tool_calls_count_distribution": {
+          "2": 16,
+          "1": 45,
+          "3": 15,
+          "4": 4,
+          "5": 3,
+          "9": 1
+        },
+        "error_only_reasoning_checked_count": 101,
+        "error_only_reasoning_count": 0,
+        "error_only_reasoning_rate": 0.0,
+        "success_rate": 1.0,
+        "tool_calls_accuracy": 0.9802
+      },
+      "output_file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.7_retry_20260401_200428/loop_03/MiniMax-M2.7/MiniMax-M2.7_results.jsonl",
+      "summary_file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.7_retry_20260401_200428/loop_03/MiniMax-M2.7/MiniMax-M2.7_summary.json",
+      "completed_at": "2026-04-01T20:14:01.682706"
+    }
+  ],
+  "generated_at": "2026-04-01T20:14:01.693021"
+}

--- a/output-dir/MiniMax-M2.7/loop_04/MiniMax-M2.7/MiniMax-M2.7_summary.json
+++ b/output-dir/MiniMax-M2.7/loop_04/MiniMax-M2.7/MiniMax-M2.7_summary.json
@@ -1,0 +1,32 @@
+{
+    "model": "minimax-m2.7",
+    "success_count": 101,
+    "failure_count": 0,
+    "all_count": 101,
+    "language_following_checked_count": 2,
+    "language_following_valid_count": 2,
+    "language_following_invalid_count": 0,
+    "tool_calls_finish_tool_calls": 84,
+    "tool_calls_finish_stop": 0,
+    "stop_finish_tool_calls": 0,
+    "stop_finish_stop": 15,
+    "tool_calls_finish_others": 0,
+    "tool_calls_finish_others_detail": {},
+    "expected_tool_call_total_count": 99,
+    "tool_calls_schema_validation_error_count": 2,
+    "tool_calls_successful_count": 82,
+    "tool_calls_total_count": 166,
+    "tool_calls_count_distribution": {
+        "2": 14,
+        "1": 45,
+        "3": 15,
+        "4": 6,
+        "5": 3,
+        "9": 1
+    },
+    "error_only_reasoning_checked_count": 101,
+    "error_only_reasoning_count": 0,
+    "error_only_reasoning_rate": 0.0,
+    "success_rate": 1.0,
+    "tool_calls_accuracy": 0.9802
+}

--- a/output-dir/MiniMax-M2.7/loop_04/MiniMax-M2.7/batch_report.json
+++ b/output-dir/MiniMax-M2.7/loop_04/MiniMax-M2.7/batch_report.json
@@ -1,0 +1,48 @@
+{
+  "test_file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.7_retry_20260401_200428/loop_04/MiniMax-M2.7/test_data.jsonl",
+  "total_providers": 1,
+  "successful_providers": 1,
+  "failed_providers": 0,
+  "provider_results": [
+    {
+      "provider": "MiniMax-M2.7",
+      "status": "success",
+      "summary": {
+        "model": "minimax-m2.7",
+        "success_count": 101,
+        "failure_count": 0,
+        "all_count": 101,
+        "language_following_checked_count": 2,
+        "language_following_valid_count": 2,
+        "language_following_invalid_count": 0,
+        "tool_calls_finish_tool_calls": 84,
+        "tool_calls_finish_stop": 0,
+        "stop_finish_tool_calls": 0,
+        "stop_finish_stop": 15,
+        "tool_calls_finish_others": 0,
+        "tool_calls_finish_others_detail": {},
+        "expected_tool_call_total_count": 99,
+        "tool_calls_schema_validation_error_count": 2,
+        "tool_calls_successful_count": 82,
+        "tool_calls_total_count": 166,
+        "tool_calls_count_distribution": {
+          "2": 14,
+          "1": 45,
+          "3": 15,
+          "4": 6,
+          "5": 3,
+          "9": 1
+        },
+        "error_only_reasoning_checked_count": 101,
+        "error_only_reasoning_count": 0,
+        "error_only_reasoning_rate": 0.0,
+        "success_rate": 1.0,
+        "tool_calls_accuracy": 0.9802
+      },
+      "output_file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.7_retry_20260401_200428/loop_04/MiniMax-M2.7/MiniMax-M2.7_results.jsonl",
+      "summary_file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.7_retry_20260401_200428/loop_04/MiniMax-M2.7/MiniMax-M2.7_summary.json",
+      "completed_at": "2026-04-01T20:19:02.951262"
+    }
+  ],
+  "generated_at": "2026-04-01T20:19:02.984000"
+}

--- a/output-dir/MiniMax-M2.7/loop_05/MiniMax-M2.7/MiniMax-M2.7_summary.json
+++ b/output-dir/MiniMax-M2.7/loop_05/MiniMax-M2.7/MiniMax-M2.7_summary.json
@@ -1,0 +1,32 @@
+{
+    "model": "minimax-m2.7",
+    "success_count": 101,
+    "failure_count": 0,
+    "all_count": 101,
+    "tool_calls_finish_tool_calls": 84,
+    "tool_calls_finish_stop": 0,
+    "stop_finish_tool_calls": 0,
+    "stop_finish_stop": 15,
+    "tool_calls_finish_others": 0,
+    "tool_calls_finish_others_detail": {},
+    "expected_tool_call_total_count": 99,
+    "tool_calls_schema_validation_error_count": 4,
+    "tool_calls_successful_count": 80,
+    "tool_calls_total_count": 155,
+    "tool_calls_count_distribution": {
+        "2": 11,
+        "1": 50,
+        "3": 14,
+        "5": 3,
+        "4": 5,
+        "6": 1
+    },
+    "language_following_checked_count": 2,
+    "language_following_valid_count": 2,
+    "language_following_invalid_count": 0,
+    "error_only_reasoning_checked_count": 101,
+    "error_only_reasoning_count": 0,
+    "error_only_reasoning_rate": 0.0,
+    "success_rate": 1.0,
+    "tool_calls_accuracy": 0.9802
+}

--- a/output-dir/MiniMax-M2.7/loop_05/MiniMax-M2.7/batch_report.json
+++ b/output-dir/MiniMax-M2.7/loop_05/MiniMax-M2.7/batch_report.json
@@ -1,0 +1,48 @@
+{
+  "test_file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.7_retry_20260401_200428/loop_05/MiniMax-M2.7/test_data.jsonl",
+  "total_providers": 1,
+  "successful_providers": 1,
+  "failed_providers": 0,
+  "provider_results": [
+    {
+      "provider": "MiniMax-M2.7",
+      "status": "success",
+      "summary": {
+        "model": "minimax-m2.7",
+        "success_count": 101,
+        "failure_count": 0,
+        "all_count": 101,
+        "tool_calls_finish_tool_calls": 84,
+        "tool_calls_finish_stop": 0,
+        "stop_finish_tool_calls": 0,
+        "stop_finish_stop": 15,
+        "tool_calls_finish_others": 0,
+        "tool_calls_finish_others_detail": {},
+        "expected_tool_call_total_count": 99,
+        "tool_calls_schema_validation_error_count": 4,
+        "tool_calls_successful_count": 80,
+        "tool_calls_total_count": 155,
+        "tool_calls_count_distribution": {
+          "2": 11,
+          "1": 50,
+          "3": 14,
+          "5": 3,
+          "4": 5,
+          "6": 1
+        },
+        "language_following_checked_count": 2,
+        "language_following_valid_count": 2,
+        "language_following_invalid_count": 0,
+        "error_only_reasoning_checked_count": 101,
+        "error_only_reasoning_count": 0,
+        "error_only_reasoning_rate": 0.0,
+        "success_rate": 1.0,
+        "tool_calls_accuracy": 0.9802
+      },
+      "output_file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.7_retry_20260401_200428/loop_05/MiniMax-M2.7/MiniMax-M2.7_results.jsonl",
+      "summary_file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.7_retry_20260401_200428/loop_05/MiniMax-M2.7/MiniMax-M2.7_summary.json",
+      "completed_at": "2026-04-01T20:20:43.898387"
+    }
+  ],
+  "generated_at": "2026-04-01T20:20:43.904383"
+}

--- a/output-dir/MiniMax-M2.7/loop_06/MiniMax-M2.7/MiniMax-M2.7_summary.json
+++ b/output-dir/MiniMax-M2.7/loop_06/MiniMax-M2.7/MiniMax-M2.7_summary.json
@@ -1,0 +1,32 @@
+{
+    "model": "minimax-m2.7",
+    "success_count": 101,
+    "failure_count": 0,
+    "all_count": 101,
+    "language_following_checked_count": 2,
+    "language_following_valid_count": 2,
+    "language_following_invalid_count": 0,
+    "tool_calls_finish_tool_calls": 83,
+    "tool_calls_finish_stop": 1,
+    "stop_finish_tool_calls": 1,
+    "stop_finish_stop": 14,
+    "tool_calls_finish_others": 0,
+    "tool_calls_finish_others_detail": {},
+    "expected_tool_call_total_count": 99,
+    "tool_calls_schema_validation_error_count": 4,
+    "tool_calls_successful_count": 79,
+    "tool_calls_total_count": 157,
+    "tool_calls_count_distribution": {
+        "2": 14,
+        "1": 48,
+        "4": 5,
+        "5": 3,
+        "3": 12,
+        "9": 1
+    },
+    "error_only_reasoning_checked_count": 101,
+    "error_only_reasoning_count": 0,
+    "error_only_reasoning_rate": 0.0,
+    "success_rate": 1.0,
+    "tool_calls_accuracy": 0.9604
+}

--- a/output-dir/MiniMax-M2.7/loop_06/MiniMax-M2.7/batch_report.json
+++ b/output-dir/MiniMax-M2.7/loop_06/MiniMax-M2.7/batch_report.json
@@ -1,0 +1,48 @@
+{
+  "test_file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.7_retry_20260401_200428/loop_06/MiniMax-M2.7/test_data.jsonl",
+  "total_providers": 1,
+  "successful_providers": 1,
+  "failed_providers": 0,
+  "provider_results": [
+    {
+      "provider": "MiniMax-M2.7",
+      "status": "success",
+      "summary": {
+        "model": "minimax-m2.7",
+        "success_count": 101,
+        "failure_count": 0,
+        "all_count": 101,
+        "language_following_checked_count": 2,
+        "language_following_valid_count": 2,
+        "language_following_invalid_count": 0,
+        "tool_calls_finish_tool_calls": 83,
+        "tool_calls_finish_stop": 1,
+        "stop_finish_tool_calls": 1,
+        "stop_finish_stop": 14,
+        "tool_calls_finish_others": 0,
+        "tool_calls_finish_others_detail": {},
+        "expected_tool_call_total_count": 99,
+        "tool_calls_schema_validation_error_count": 4,
+        "tool_calls_successful_count": 79,
+        "tool_calls_total_count": 157,
+        "tool_calls_count_distribution": {
+          "2": 14,
+          "1": 48,
+          "4": 5,
+          "5": 3,
+          "3": 12,
+          "9": 1
+        },
+        "error_only_reasoning_checked_count": 101,
+        "error_only_reasoning_count": 0,
+        "error_only_reasoning_rate": 0.0,
+        "success_rate": 1.0,
+        "tool_calls_accuracy": 0.9604
+      },
+      "output_file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.7_retry_20260401_200428/loop_06/MiniMax-M2.7/MiniMax-M2.7_results.jsonl",
+      "summary_file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.7_retry_20260401_200428/loop_06/MiniMax-M2.7/MiniMax-M2.7_summary.json",
+      "completed_at": "2026-04-01T20:22:27.334723"
+    }
+  ],
+  "generated_at": "2026-04-01T20:22:27.341544"
+}

--- a/output-dir/MiniMax-M2.7/loop_07/MiniMax-M2.7/MiniMax-M2.7_summary.json
+++ b/output-dir/MiniMax-M2.7/loop_07/MiniMax-M2.7/MiniMax-M2.7_summary.json
@@ -1,0 +1,32 @@
+{
+    "model": "minimax-m2.7",
+    "success_count": 101,
+    "failure_count": 0,
+    "all_count": 101,
+    "language_following_checked_count": 2,
+    "language_following_valid_count": 0,
+    "language_following_invalid_count": 2,
+    "tool_calls_finish_tool_calls": 84,
+    "tool_calls_finish_stop": 0,
+    "stop_finish_tool_calls": 0,
+    "stop_finish_stop": 15,
+    "tool_calls_finish_others": 0,
+    "tool_calls_finish_others_detail": {},
+    "expected_tool_call_total_count": 99,
+    "tool_calls_schema_validation_error_count": 4,
+    "tool_calls_successful_count": 80,
+    "tool_calls_total_count": 161,
+    "tool_calls_count_distribution": {
+        "1": 49,
+        "2": 10,
+        "3": 16,
+        "4": 5,
+        "5": 3,
+        "9": 1
+    },
+    "error_only_reasoning_checked_count": 101,
+    "error_only_reasoning_count": 0,
+    "error_only_reasoning_rate": 0.0,
+    "success_rate": 1.0,
+    "tool_calls_accuracy": 0.9802
+}

--- a/output-dir/MiniMax-M2.7/loop_07/MiniMax-M2.7/batch_report.json
+++ b/output-dir/MiniMax-M2.7/loop_07/MiniMax-M2.7/batch_report.json
@@ -1,0 +1,48 @@
+{
+  "test_file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.7_retry_20260401_200428/loop_07/MiniMax-M2.7/test_data.jsonl",
+  "total_providers": 1,
+  "successful_providers": 1,
+  "failed_providers": 0,
+  "provider_results": [
+    {
+      "provider": "MiniMax-M2.7",
+      "status": "success",
+      "summary": {
+        "model": "minimax-m2.7",
+        "success_count": 101,
+        "failure_count": 0,
+        "all_count": 101,
+        "language_following_checked_count": 2,
+        "language_following_valid_count": 0,
+        "language_following_invalid_count": 2,
+        "tool_calls_finish_tool_calls": 84,
+        "tool_calls_finish_stop": 0,
+        "stop_finish_tool_calls": 0,
+        "stop_finish_stop": 15,
+        "tool_calls_finish_others": 0,
+        "tool_calls_finish_others_detail": {},
+        "expected_tool_call_total_count": 99,
+        "tool_calls_schema_validation_error_count": 4,
+        "tool_calls_successful_count": 80,
+        "tool_calls_total_count": 161,
+        "tool_calls_count_distribution": {
+          "1": 49,
+          "2": 10,
+          "3": 16,
+          "4": 5,
+          "5": 3,
+          "9": 1
+        },
+        "error_only_reasoning_checked_count": 101,
+        "error_only_reasoning_count": 0,
+        "error_only_reasoning_rate": 0.0,
+        "success_rate": 1.0,
+        "tool_calls_accuracy": 0.9802
+      },
+      "output_file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.7_retry_20260401_200428/loop_07/MiniMax-M2.7/MiniMax-M2.7_results.jsonl",
+      "summary_file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.7_retry_20260401_200428/loop_07/MiniMax-M2.7/MiniMax-M2.7_summary.json",
+      "completed_at": "2026-04-01T20:24:55.230801"
+    }
+  ],
+  "generated_at": "2026-04-01T20:24:55.237632"
+}

--- a/output-dir/MiniMax-M2.7/loop_08/MiniMax-M2.7/MiniMax-M2.7_summary.json
+++ b/output-dir/MiniMax-M2.7/loop_08/MiniMax-M2.7/MiniMax-M2.7_summary.json
@@ -1,0 +1,32 @@
+{
+    "model": "minimax-m2.7",
+    "success_count": 101,
+    "failure_count": 0,
+    "all_count": 101,
+    "tool_calls_finish_tool_calls": 84,
+    "tool_calls_finish_stop": 0,
+    "stop_finish_tool_calls": 1,
+    "stop_finish_stop": 14,
+    "tool_calls_finish_others": 0,
+    "tool_calls_finish_others_detail": {},
+    "expected_tool_call_total_count": 99,
+    "tool_calls_schema_validation_error_count": 2,
+    "tool_calls_successful_count": 82,
+    "tool_calls_total_count": 165,
+    "tool_calls_count_distribution": {
+        "2": 13,
+        "1": 47,
+        "3": 13,
+        "4": 7,
+        "5": 3,
+        "9": 1
+    },
+    "language_following_checked_count": 2,
+    "language_following_valid_count": 2,
+    "language_following_invalid_count": 0,
+    "error_only_reasoning_checked_count": 101,
+    "error_only_reasoning_count": 0,
+    "error_only_reasoning_rate": 0.0,
+    "success_rate": 1.0,
+    "tool_calls_accuracy": 0.9703
+}

--- a/output-dir/MiniMax-M2.7/loop_08/MiniMax-M2.7/batch_report.json
+++ b/output-dir/MiniMax-M2.7/loop_08/MiniMax-M2.7/batch_report.json
@@ -1,0 +1,48 @@
+{
+  "test_file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.7_retry_20260401_200428/loop_08/MiniMax-M2.7/test_data.jsonl",
+  "total_providers": 1,
+  "successful_providers": 1,
+  "failed_providers": 0,
+  "provider_results": [
+    {
+      "provider": "MiniMax-M2.7",
+      "status": "success",
+      "summary": {
+        "model": "minimax-m2.7",
+        "success_count": 101,
+        "failure_count": 0,
+        "all_count": 101,
+        "tool_calls_finish_tool_calls": 84,
+        "tool_calls_finish_stop": 0,
+        "stop_finish_tool_calls": 1,
+        "stop_finish_stop": 14,
+        "tool_calls_finish_others": 0,
+        "tool_calls_finish_others_detail": {},
+        "expected_tool_call_total_count": 99,
+        "tool_calls_schema_validation_error_count": 2,
+        "tool_calls_successful_count": 82,
+        "tool_calls_total_count": 165,
+        "tool_calls_count_distribution": {
+          "2": 13,
+          "1": 47,
+          "3": 13,
+          "4": 7,
+          "5": 3,
+          "9": 1
+        },
+        "language_following_checked_count": 2,
+        "language_following_valid_count": 2,
+        "language_following_invalid_count": 0,
+        "error_only_reasoning_checked_count": 101,
+        "error_only_reasoning_count": 0,
+        "error_only_reasoning_rate": 0.0,
+        "success_rate": 1.0,
+        "tool_calls_accuracy": 0.9703
+      },
+      "output_file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.7_retry_20260401_200428/loop_08/MiniMax-M2.7/MiniMax-M2.7_results.jsonl",
+      "summary_file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.7_retry_20260401_200428/loop_08/MiniMax-M2.7/MiniMax-M2.7_summary.json",
+      "completed_at": "2026-04-01T20:26:56.531190"
+    }
+  ],
+  "generated_at": "2026-04-01T20:26:56.537085"
+}

--- a/output-dir/MiniMax-M2.7/loop_09/MiniMax-M2.7/MiniMax-M2.7_summary.json
+++ b/output-dir/MiniMax-M2.7/loop_09/MiniMax-M2.7/MiniMax-M2.7_summary.json
@@ -1,0 +1,32 @@
+{
+    "model": "minimax-m2.7",
+    "success_count": 101,
+    "failure_count": 0,
+    "all_count": 101,
+    "language_following_checked_count": 2,
+    "language_following_valid_count": 2,
+    "language_following_invalid_count": 0,
+    "tool_calls_finish_tool_calls": 84,
+    "tool_calls_finish_stop": 0,
+    "stop_finish_tool_calls": 2,
+    "stop_finish_stop": 13,
+    "tool_calls_finish_others": 0,
+    "tool_calls_finish_others_detail": {},
+    "expected_tool_call_total_count": 99,
+    "tool_calls_schema_validation_error_count": 4,
+    "tool_calls_successful_count": 80,
+    "tool_calls_total_count": 165,
+    "tool_calls_count_distribution": {
+        "2": 10,
+        "1": 49,
+        "3": 14,
+        "4": 7,
+        "5": 3,
+        "9": 1
+    },
+    "error_only_reasoning_checked_count": 101,
+    "error_only_reasoning_count": 0,
+    "error_only_reasoning_rate": 0.0,
+    "success_rate": 1.0,
+    "tool_calls_accuracy": 0.9604
+}

--- a/output-dir/MiniMax-M2.7/loop_09/MiniMax-M2.7/batch_report.json
+++ b/output-dir/MiniMax-M2.7/loop_09/MiniMax-M2.7/batch_report.json
@@ -1,0 +1,48 @@
+{
+  "test_file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.7_retry_20260401_200428/loop_09/MiniMax-M2.7/test_data.jsonl",
+  "total_providers": 1,
+  "successful_providers": 1,
+  "failed_providers": 0,
+  "provider_results": [
+    {
+      "provider": "MiniMax-M2.7",
+      "status": "success",
+      "summary": {
+        "model": "minimax-m2.7",
+        "success_count": 101,
+        "failure_count": 0,
+        "all_count": 101,
+        "language_following_checked_count": 2,
+        "language_following_valid_count": 2,
+        "language_following_invalid_count": 0,
+        "tool_calls_finish_tool_calls": 84,
+        "tool_calls_finish_stop": 0,
+        "stop_finish_tool_calls": 2,
+        "stop_finish_stop": 13,
+        "tool_calls_finish_others": 0,
+        "tool_calls_finish_others_detail": {},
+        "expected_tool_call_total_count": 99,
+        "tool_calls_schema_validation_error_count": 4,
+        "tool_calls_successful_count": 80,
+        "tool_calls_total_count": 165,
+        "tool_calls_count_distribution": {
+          "2": 10,
+          "1": 49,
+          "3": 14,
+          "4": 7,
+          "5": 3,
+          "9": 1
+        },
+        "error_only_reasoning_checked_count": 101,
+        "error_only_reasoning_count": 0,
+        "error_only_reasoning_rate": 0.0,
+        "success_rate": 1.0,
+        "tool_calls_accuracy": 0.9604
+      },
+      "output_file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.7_retry_20260401_200428/loop_09/MiniMax-M2.7/MiniMax-M2.7_results.jsonl",
+      "summary_file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.7_retry_20260401_200428/loop_09/MiniMax-M2.7/MiniMax-M2.7_summary.json",
+      "completed_at": "2026-04-01T20:29:53.918250"
+    }
+  ],
+  "generated_at": "2026-04-01T20:29:53.923919"
+}

--- a/output-dir/MiniMax-M2.7/loop_10/MiniMax-M2.7/MiniMax-M2.7_summary.json
+++ b/output-dir/MiniMax-M2.7/loop_10/MiniMax-M2.7/MiniMax-M2.7_summary.json
@@ -1,0 +1,32 @@
+{
+    "model": "minimax-m2.7",
+    "success_count": 101,
+    "failure_count": 0,
+    "all_count": 101,
+    "tool_calls_finish_tool_calls": 84,
+    "tool_calls_finish_stop": 0,
+    "stop_finish_tool_calls": 0,
+    "stop_finish_stop": 15,
+    "tool_calls_finish_others": 0,
+    "tool_calls_finish_others_detail": {},
+    "expected_tool_call_total_count": 99,
+    "tool_calls_schema_validation_error_count": 2,
+    "tool_calls_successful_count": 82,
+    "tool_calls_total_count": 162,
+    "tool_calls_count_distribution": {
+        "1": 48,
+        "2": 12,
+        "3": 14,
+        "4": 6,
+        "5": 3,
+        "9": 1
+    },
+    "language_following_checked_count": 2,
+    "language_following_valid_count": 1,
+    "language_following_invalid_count": 1,
+    "error_only_reasoning_checked_count": 101,
+    "error_only_reasoning_count": 0,
+    "error_only_reasoning_rate": 0.0,
+    "success_rate": 1.0,
+    "tool_calls_accuracy": 0.9802
+}

--- a/output-dir/MiniMax-M2.7/loop_10/MiniMax-M2.7/batch_report.json
+++ b/output-dir/MiniMax-M2.7/loop_10/MiniMax-M2.7/batch_report.json
@@ -1,0 +1,48 @@
+{
+  "test_file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.7_retry_20260401_200428/loop_10/MiniMax-M2.7/test_data.jsonl",
+  "total_providers": 1,
+  "successful_providers": 1,
+  "failed_providers": 0,
+  "provider_results": [
+    {
+      "provider": "MiniMax-M2.7",
+      "status": "success",
+      "summary": {
+        "model": "minimax-m2.7",
+        "success_count": 101,
+        "failure_count": 0,
+        "all_count": 101,
+        "tool_calls_finish_tool_calls": 84,
+        "tool_calls_finish_stop": 0,
+        "stop_finish_tool_calls": 0,
+        "stop_finish_stop": 15,
+        "tool_calls_finish_others": 0,
+        "tool_calls_finish_others_detail": {},
+        "expected_tool_call_total_count": 99,
+        "tool_calls_schema_validation_error_count": 2,
+        "tool_calls_successful_count": 82,
+        "tool_calls_total_count": 162,
+        "tool_calls_count_distribution": {
+          "1": 48,
+          "2": 12,
+          "3": 14,
+          "4": 6,
+          "5": 3,
+          "9": 1
+        },
+        "language_following_checked_count": 2,
+        "language_following_valid_count": 1,
+        "language_following_invalid_count": 1,
+        "error_only_reasoning_checked_count": 101,
+        "error_only_reasoning_count": 0,
+        "error_only_reasoning_rate": 0.0,
+        "success_rate": 1.0,
+        "tool_calls_accuracy": 0.9802
+      },
+      "output_file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.7_retry_20260401_200428/loop_10/MiniMax-M2.7/MiniMax-M2.7_results.jsonl",
+      "summary_file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.7_retry_20260401_200428/loop_10/MiniMax-M2.7/MiniMax-M2.7_summary.json",
+      "completed_at": "2026-04-01T20:32:07.462526"
+    }
+  ],
+  "generated_at": "2026-04-01T20:32:07.469496"
+}

--- a/output-dir/MiniMax-M2.7/metrics_report.json
+++ b/output-dir/MiniMax-M2.7/metrics_report.json
@@ -1,0 +1,124 @@
+{
+    "summary": {
+        "total_files": 10,
+        "average_metrics": {
+            "1. Query-Success-Rate": 1.0,
+            "2. ToolCalls-Match-Rate": 0.9929292929292929,
+            "4. ToolCalls-Accuracy": 0.9666092943201378,
+            "5. Response-Success-Rate-Not-Only-Reasoning": 1.0,
+            "6. Language-Following-Success-Rate": 0.8
+        }
+    },
+    "results": [
+        {
+            "file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.7_retry_20260401_200428/loop_01/MiniMax-M2.7/MiniMax-M2.7_summary.json",
+            "model": "minimax-m2.7",
+            "metrics": {
+                "1. Query-Success-Rate": 1.0,
+                "2. ToolCalls-Match-Rate": 0.98989898989899,
+                "4. ToolCalls-Accuracy": 0.9880952380952381,
+                "5. Response-Success-Rate-Not-Only-Reasoning": 1.0,
+                "6. Language-Following-Success-Rate": 1.0
+            }
+        },
+        {
+            "file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.7_retry_20260401_200428/loop_02/MiniMax-M2.7/MiniMax-M2.7_summary.json",
+            "model": "minimax-m2.7",
+            "metrics": {
+                "1. Query-Success-Rate": 1.0,
+                "2. ToolCalls-Match-Rate": 0.98989898989899,
+                "4. ToolCalls-Accuracy": 0.9642857142857143,
+                "5. Response-Success-Rate-Not-Only-Reasoning": 1.0,
+                "6. Language-Following-Success-Rate": 0.5
+            }
+        },
+        {
+            "file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.7_retry_20260401_200428/loop_03/MiniMax-M2.7/MiniMax-M2.7_summary.json",
+            "model": "minimax-m2.7",
+            "metrics": {
+                "1. Query-Success-Rate": 1.0,
+                "2. ToolCalls-Match-Rate": 1.0,
+                "4. ToolCalls-Accuracy": 0.9761904761904762,
+                "5. Response-Success-Rate-Not-Only-Reasoning": 1.0,
+                "6. Language-Following-Success-Rate": 1.0
+            }
+        },
+        {
+            "file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.7_retry_20260401_200428/loop_04/MiniMax-M2.7/MiniMax-M2.7_summary.json",
+            "model": "minimax-m2.7",
+            "metrics": {
+                "1. Query-Success-Rate": 1.0,
+                "2. ToolCalls-Match-Rate": 1.0,
+                "4. ToolCalls-Accuracy": 0.9761904761904762,
+                "5. Response-Success-Rate-Not-Only-Reasoning": 1.0,
+                "6. Language-Following-Success-Rate": 1.0
+            }
+        },
+        {
+            "file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.7_retry_20260401_200428/loop_05/MiniMax-M2.7/MiniMax-M2.7_summary.json",
+            "model": "minimax-m2.7",
+            "metrics": {
+                "1. Query-Success-Rate": 1.0,
+                "2. ToolCalls-Match-Rate": 1.0,
+                "4. ToolCalls-Accuracy": 0.9523809523809523,
+                "5. Response-Success-Rate-Not-Only-Reasoning": 1.0,
+                "6. Language-Following-Success-Rate": 1.0
+            }
+        },
+        {
+            "file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.7_retry_20260401_200428/loop_06/MiniMax-M2.7/MiniMax-M2.7_summary.json",
+            "model": "minimax-m2.7",
+            "metrics": {
+                "1. Query-Success-Rate": 1.0,
+                "2. ToolCalls-Match-Rate": 0.9797979797979798,
+                "4. ToolCalls-Accuracy": 0.9518072289156626,
+                "5. Response-Success-Rate-Not-Only-Reasoning": 1.0,
+                "6. Language-Following-Success-Rate": 1.0
+            }
+        },
+        {
+            "file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.7_retry_20260401_200428/loop_07/MiniMax-M2.7/MiniMax-M2.7_summary.json",
+            "model": "minimax-m2.7",
+            "metrics": {
+                "1. Query-Success-Rate": 1.0,
+                "2. ToolCalls-Match-Rate": 1.0,
+                "4. ToolCalls-Accuracy": 0.9523809523809523,
+                "5. Response-Success-Rate-Not-Only-Reasoning": 1.0,
+                "6. Language-Following-Success-Rate": 0.0
+            }
+        },
+        {
+            "file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.7_retry_20260401_200428/loop_08/MiniMax-M2.7/MiniMax-M2.7_summary.json",
+            "model": "minimax-m2.7",
+            "metrics": {
+                "1. Query-Success-Rate": 1.0,
+                "2. ToolCalls-Match-Rate": 0.98989898989899,
+                "4. ToolCalls-Accuracy": 0.9761904761904762,
+                "5. Response-Success-Rate-Not-Only-Reasoning": 1.0,
+                "6. Language-Following-Success-Rate": 1.0
+            }
+        },
+        {
+            "file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.7_retry_20260401_200428/loop_09/MiniMax-M2.7/MiniMax-M2.7_summary.json",
+            "model": "minimax-m2.7",
+            "metrics": {
+                "1. Query-Success-Rate": 1.0,
+                "2. ToolCalls-Match-Rate": 0.9797979797979798,
+                "4. ToolCalls-Accuracy": 0.9523809523809523,
+                "5. Response-Success-Rate-Not-Only-Reasoning": 1.0,
+                "6. Language-Following-Success-Rate": 1.0
+            }
+        },
+        {
+            "file": "/Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.7_retry_20260401_200428/loop_10/MiniMax-M2.7/MiniMax-M2.7_summary.json",
+            "model": "minimax-m2.7",
+            "metrics": {
+                "1. Query-Success-Rate": 1.0,
+                "2. ToolCalls-Match-Rate": 1.0,
+                "4. ToolCalls-Accuracy": 0.9761904761904762,
+                "5. Response-Success-Rate-Not-Only-Reasoning": 1.0,
+                "6. Language-Following-Success-Rate": 0.5
+            }
+        }
+    ]
+}

--- a/output-dir/MiniMax-M2.7/monitor.log
+++ b/output-dir/MiniMax-M2.7/monitor.log
@@ -1,0 +1,307 @@
+[2026-04-01 20:04:28] ========== Starting minimax-m2.7 batch test ==========
+[2026-04-01 20:04:28] Target: 10 clean loops, max_workers=50
+[2026-04-01 20:04:28] Output: /Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.7_retry_20260401_200428
+[2026-04-01 20:04:28] --- Loop 01 (clean=0/10) starting ---
+[2026-04-01 20:06:58] OK: Loop 01 clean (success=101, failure=0) [1/10]
+[2026-04-01 20:06:58] --- Loop 02 (clean=1/10) starting ---
+[2026-04-01 20:09:23] OK: Loop 02 clean (success=101, failure=0) [2/10]
+[2026-04-01 20:09:23] --- Loop 03 (clean=2/10) starting ---
+[2026-04-01 20:14:02] OK: Loop 03 clean (success=101, failure=0) [3/10]
+[2026-04-01 20:14:02] --- Loop 04 (clean=3/10) starting ---
+[2026-04-01 20:19:03] OK: Loop 04 clean (success=101, failure=0) [4/10]
+[2026-04-01 20:19:04] --- Loop 05 (clean=4/10) starting ---
+[2026-04-01 20:20:44] OK: Loop 05 clean (success=101, failure=0) [5/10]
+[2026-04-01 20:20:44] --- Loop 06 (clean=5/10) starting ---
+[2026-04-01 20:22:27] OK: Loop 06 clean (success=101, failure=0) [6/10]
+[2026-04-01 20:22:28] --- Loop 07 (clean=6/10) starting ---
+[2026-04-01 20:24:55] OK: Loop 07 clean (success=101, failure=0) [7/10]
+[2026-04-01 20:24:55] --- Loop 08 (clean=7/10) starting ---
+[2026-04-01 20:26:56] OK: Loop 08 clean (success=101, failure=0) [8/10]
+[2026-04-01 20:26:57] --- Loop 09 (clean=8/10) starting ---
+[2026-04-01 20:29:54] OK: Loop 09 clean (success=101, failure=0) [9/10]
+[2026-04-01 20:29:54] --- Loop 10 (clean=9/10) starting ---
+[2026-04-01 20:32:08] OK: Loop 10 clean (success=101, failure=0) [10/10]
+[2026-04-01 20:32:08] ========== DONE: minimax-m2.7 ==========
+[2026-04-01 20:32:08] Collected 10 clean loops in 10 total runs
+[2026-04-01 20:32:08] Failed loops: none
+[2026-04-01 20:32:08] Collecting metrics...
+Read expected_tool_call statistics from /Users/minimax/GitHub/MiniMax-Provider-Verifier/sample.jsonl:
+  - expected_tool_call=True: 84
+  - expected_tool_call=False: 15
+  - Total (Match-Rate denominator): 99
+Searching directory: /Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.7_retry_20260401_200428
+Specified provider: MiniMax-M2.7
+
+Total 10 files found
+
+Files found:
+  1. /Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.7_retry_20260401_200428/loop_01/MiniMax-M2.7/MiniMax-M2.7_summary.json
+  2. /Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.7_retry_20260401_200428/loop_02/MiniMax-M2.7/MiniMax-M2.7_summary.json
+  3. /Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.7_retry_20260401_200428/loop_03/MiniMax-M2.7/MiniMax-M2.7_summary.json
+  4. /Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.7_retry_20260401_200428/loop_04/MiniMax-M2.7/MiniMax-M2.7_summary.json
+  5. /Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.7_retry_20260401_200428/loop_05/MiniMax-M2.7/MiniMax-M2.7_summary.json
+  6. /Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.7_retry_20260401_200428/loop_06/MiniMax-M2.7/MiniMax-M2.7_summary.json
+  7. /Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.7_retry_20260401_200428/loop_07/MiniMax-M2.7/MiniMax-M2.7_summary.json
+  8. /Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.7_retry_20260401_200428/loop_08/MiniMax-M2.7/MiniMax-M2.7_summary.json
+  9. /Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.7_retry_20260401_200428/loop_09/MiniMax-M2.7/MiniMax-M2.7_summary.json
+  10. /Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.7_retry_20260401_200428/loop_10/MiniMax-M2.7/MiniMax-M2.7_summary.json
+Warning: Reference folder does not exist: /Users/minimax/GitHub/MiniMax-Provider-Verifier/MiniMax-M2.7
+
+================================================================================
+File: /Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.7_retry_20260401_200428/loop_01/MiniMax-M2.7/MiniMax-M2.7_summary.json
+Model: minimax-m2.7
+--------------------------------------------------------------------------------
+Raw Data:
+  - Total queries (all_count): 101
+  - Success count (success_count): 101
+  - Failure count (failure_count): 0
+  - ToolCalls finish count (tool_calls_finish_tool_calls): 84
+  - ToolCalls success count (tool_calls_successful_count): 83
+  - Only reasoning error checked (error_only_reasoning_checked_count): 101
+  - Only reasoning error count (error_only_reasoning_count): 0
+  - Language following checked (language_following_checked_count): 2
+  - Language following valid (language_following_valid_count): 2
+--------------------------------------------------------------------------------
+Calculated Metrics:
+  1. Query-Success-Rate: 1.0000 (100.00%)
+  2. ToolCalls-Match-Rate: 0.9899 (98.99%)
+  4. ToolCalls-Accuracy: 0.9881 (98.81%)
+  5. Response-Success-Rate-Not-Only-Reasoning: 1.0000 (100.00%)
+  6. Language-Following-Success-Rate: 1.0000 (100.00%)
+================================================================================
+
+================================================================================
+File: /Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.7_retry_20260401_200428/loop_02/MiniMax-M2.7/MiniMax-M2.7_summary.json
+Model: minimax-m2.7
+--------------------------------------------------------------------------------
+Raw Data:
+  - Total queries (all_count): 101
+  - Success count (success_count): 101
+  - Failure count (failure_count): 0
+  - ToolCalls finish count (tool_calls_finish_tool_calls): 84
+  - ToolCalls success count (tool_calls_successful_count): 81
+  - Only reasoning error checked (error_only_reasoning_checked_count): 101
+  - Only reasoning error count (error_only_reasoning_count): 0
+  - Language following checked (language_following_checked_count): 2
+  - Language following valid (language_following_valid_count): 1
+--------------------------------------------------------------------------------
+Calculated Metrics:
+  1. Query-Success-Rate: 1.0000 (100.00%)
+  2. ToolCalls-Match-Rate: 0.9899 (98.99%)
+  4. ToolCalls-Accuracy: 0.9643 (96.43%)
+  5. Response-Success-Rate-Not-Only-Reasoning: 1.0000 (100.00%)
+  6. Language-Following-Success-Rate: 0.5000 (50.00%)
+================================================================================
+
+================================================================================
+File: /Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.7_retry_20260401_200428/loop_03/MiniMax-M2.7/MiniMax-M2.7_summary.json
+Model: minimax-m2.7
+--------------------------------------------------------------------------------
+Raw Data:
+  - Total queries (all_count): 101
+  - Success count (success_count): 101
+  - Failure count (failure_count): 0
+  - ToolCalls finish count (tool_calls_finish_tool_calls): 84
+  - ToolCalls success count (tool_calls_successful_count): 82
+  - Only reasoning error checked (error_only_reasoning_checked_count): 101
+  - Only reasoning error count (error_only_reasoning_count): 0
+  - Language following checked (language_following_checked_count): 2
+  - Language following valid (language_following_valid_count): 2
+--------------------------------------------------------------------------------
+Calculated Metrics:
+  1. Query-Success-Rate: 1.0000 (100.00%)
+  2. ToolCalls-Match-Rate: 1.0000 (100.00%)
+  4. ToolCalls-Accuracy: 0.9762 (97.62%)
+  5. Response-Success-Rate-Not-Only-Reasoning: 1.0000 (100.00%)
+  6. Language-Following-Success-Rate: 1.0000 (100.00%)
+================================================================================
+
+================================================================================
+File: /Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.7_retry_20260401_200428/loop_04/MiniMax-M2.7/MiniMax-M2.7_summary.json
+Model: minimax-m2.7
+--------------------------------------------------------------------------------
+Raw Data:
+  - Total queries (all_count): 101
+  - Success count (success_count): 101
+  - Failure count (failure_count): 0
+  - ToolCalls finish count (tool_calls_finish_tool_calls): 84
+  - ToolCalls success count (tool_calls_successful_count): 82
+  - Only reasoning error checked (error_only_reasoning_checked_count): 101
+  - Only reasoning error count (error_only_reasoning_count): 0
+  - Language following checked (language_following_checked_count): 2
+  - Language following valid (language_following_valid_count): 2
+--------------------------------------------------------------------------------
+Calculated Metrics:
+  1. Query-Success-Rate: 1.0000 (100.00%)
+  2. ToolCalls-Match-Rate: 1.0000 (100.00%)
+  4. ToolCalls-Accuracy: 0.9762 (97.62%)
+  5. Response-Success-Rate-Not-Only-Reasoning: 1.0000 (100.00%)
+  6. Language-Following-Success-Rate: 1.0000 (100.00%)
+================================================================================
+
+================================================================================
+File: /Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.7_retry_20260401_200428/loop_05/MiniMax-M2.7/MiniMax-M2.7_summary.json
+Model: minimax-m2.7
+--------------------------------------------------------------------------------
+Raw Data:
+  - Total queries (all_count): 101
+  - Success count (success_count): 101
+  - Failure count (failure_count): 0
+  - ToolCalls finish count (tool_calls_finish_tool_calls): 84
+  - ToolCalls success count (tool_calls_successful_count): 80
+  - Only reasoning error checked (error_only_reasoning_checked_count): 101
+  - Only reasoning error count (error_only_reasoning_count): 0
+  - Language following checked (language_following_checked_count): 2
+  - Language following valid (language_following_valid_count): 2
+--------------------------------------------------------------------------------
+Calculated Metrics:
+  1. Query-Success-Rate: 1.0000 (100.00%)
+  2. ToolCalls-Match-Rate: 1.0000 (100.00%)
+  4. ToolCalls-Accuracy: 0.9524 (95.24%)
+  5. Response-Success-Rate-Not-Only-Reasoning: 1.0000 (100.00%)
+  6. Language-Following-Success-Rate: 1.0000 (100.00%)
+================================================================================
+
+================================================================================
+File: /Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.7_retry_20260401_200428/loop_06/MiniMax-M2.7/MiniMax-M2.7_summary.json
+Model: minimax-m2.7
+--------------------------------------------------------------------------------
+Raw Data:
+  - Total queries (all_count): 101
+  - Success count (success_count): 101
+  - Failure count (failure_count): 0
+  - ToolCalls finish count (tool_calls_finish_tool_calls): 83
+  - ToolCalls success count (tool_calls_successful_count): 79
+  - Only reasoning error checked (error_only_reasoning_checked_count): 101
+  - Only reasoning error count (error_only_reasoning_count): 0
+  - Language following checked (language_following_checked_count): 2
+  - Language following valid (language_following_valid_count): 2
+--------------------------------------------------------------------------------
+Calculated Metrics:
+  1. Query-Success-Rate: 1.0000 (100.00%)
+  2. ToolCalls-Match-Rate: 0.9798 (97.98%)
+  4. ToolCalls-Accuracy: 0.9518 (95.18%)
+  5. Response-Success-Rate-Not-Only-Reasoning: 1.0000 (100.00%)
+  6. Language-Following-Success-Rate: 1.0000 (100.00%)
+================================================================================
+
+================================================================================
+File: /Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.7_retry_20260401_200428/loop_07/MiniMax-M2.7/MiniMax-M2.7_summary.json
+Model: minimax-m2.7
+--------------------------------------------------------------------------------
+Raw Data:
+  - Total queries (all_count): 101
+  - Success count (success_count): 101
+  - Failure count (failure_count): 0
+  - ToolCalls finish count (tool_calls_finish_tool_calls): 84
+  - ToolCalls success count (tool_calls_successful_count): 80
+  - Only reasoning error checked (error_only_reasoning_checked_count): 101
+  - Only reasoning error count (error_only_reasoning_count): 0
+  - Language following checked (language_following_checked_count): 2
+  - Language following valid (language_following_valid_count): 0
+--------------------------------------------------------------------------------
+Calculated Metrics:
+  1. Query-Success-Rate: 1.0000 (100.00%)
+  2. ToolCalls-Match-Rate: 1.0000 (100.00%)
+  4. ToolCalls-Accuracy: 0.9524 (95.24%)
+  5. Response-Success-Rate-Not-Only-Reasoning: 1.0000 (100.00%)
+  6. Language-Following-Success-Rate: 0.0000 (0.00%)
+================================================================================
+
+================================================================================
+File: /Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.7_retry_20260401_200428/loop_08/MiniMax-M2.7/MiniMax-M2.7_summary.json
+Model: minimax-m2.7
+--------------------------------------------------------------------------------
+Raw Data:
+  - Total queries (all_count): 101
+  - Success count (success_count): 101
+  - Failure count (failure_count): 0
+  - ToolCalls finish count (tool_calls_finish_tool_calls): 84
+  - ToolCalls success count (tool_calls_successful_count): 82
+  - Only reasoning error checked (error_only_reasoning_checked_count): 101
+  - Only reasoning error count (error_only_reasoning_count): 0
+  - Language following checked (language_following_checked_count): 2
+  - Language following valid (language_following_valid_count): 2
+--------------------------------------------------------------------------------
+Calculated Metrics:
+  1. Query-Success-Rate: 1.0000 (100.00%)
+  2. ToolCalls-Match-Rate: 0.9899 (98.99%)
+  4. ToolCalls-Accuracy: 0.9762 (97.62%)
+  5. Response-Success-Rate-Not-Only-Reasoning: 1.0000 (100.00%)
+  6. Language-Following-Success-Rate: 1.0000 (100.00%)
+================================================================================
+
+================================================================================
+File: /Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.7_retry_20260401_200428/loop_09/MiniMax-M2.7/MiniMax-M2.7_summary.json
+Model: minimax-m2.7
+--------------------------------------------------------------------------------
+Raw Data:
+  - Total queries (all_count): 101
+  - Success count (success_count): 101
+  - Failure count (failure_count): 0
+  - ToolCalls finish count (tool_calls_finish_tool_calls): 84
+  - ToolCalls success count (tool_calls_successful_count): 80
+  - Only reasoning error checked (error_only_reasoning_checked_count): 101
+  - Only reasoning error count (error_only_reasoning_count): 0
+  - Language following checked (language_following_checked_count): 2
+  - Language following valid (language_following_valid_count): 2
+--------------------------------------------------------------------------------
+Calculated Metrics:
+  1. Query-Success-Rate: 1.0000 (100.00%)
+  2. ToolCalls-Match-Rate: 0.9798 (97.98%)
+  4. ToolCalls-Accuracy: 0.9524 (95.24%)
+  5. Response-Success-Rate-Not-Only-Reasoning: 1.0000 (100.00%)
+  6. Language-Following-Success-Rate: 1.0000 (100.00%)
+================================================================================
+
+================================================================================
+File: /Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.7_retry_20260401_200428/loop_10/MiniMax-M2.7/MiniMax-M2.7_summary.json
+Model: minimax-m2.7
+--------------------------------------------------------------------------------
+Raw Data:
+  - Total queries (all_count): 101
+  - Success count (success_count): 101
+  - Failure count (failure_count): 0
+  - ToolCalls finish count (tool_calls_finish_tool_calls): 84
+  - ToolCalls success count (tool_calls_successful_count): 82
+  - Only reasoning error checked (error_only_reasoning_checked_count): 101
+  - Only reasoning error count (error_only_reasoning_count): 0
+  - Language following checked (language_following_checked_count): 2
+  - Language following valid (language_following_valid_count): 1
+--------------------------------------------------------------------------------
+Calculated Metrics:
+  1. Query-Success-Rate: 1.0000 (100.00%)
+  2. ToolCalls-Match-Rate: 1.0000 (100.00%)
+  4. ToolCalls-Accuracy: 0.9762 (97.62%)
+  5. Response-Success-Rate-Not-Only-Reasoning: 1.0000 (100.00%)
+  6. Language-Following-Success-Rate: 0.5000 (50.00%)
+================================================================================
+
+
+========================================================================================================================
+Summary Table
+========================================================================================================================
+
+File                                     Model                          Q-Succ     TC-Match   Tool-Acc   R-Succ     Lang-Succ 
+----------------------------------------------------------------------------------------------------
+MiniMax-M2.7_summary.json                minimax-m2.7                     100.00%    98.99%    98.81%   100.00%   100.00%
+MiniMax-M2.7_summary.json                minimax-m2.7                     100.00%    98.99%    96.43%   100.00%    50.00%
+MiniMax-M2.7_summary.json                minimax-m2.7                     100.00%   100.00%    97.62%   100.00%   100.00%
+MiniMax-M2.7_summary.json                minimax-m2.7                     100.00%   100.00%    97.62%   100.00%   100.00%
+MiniMax-M2.7_summary.json                minimax-m2.7                     100.00%   100.00%    95.24%   100.00%   100.00%
+MiniMax-M2.7_summary.json                minimax-m2.7                     100.00%    97.98%    95.18%   100.00%   100.00%
+MiniMax-M2.7_summary.json                minimax-m2.7                     100.00%   100.00%    95.24%   100.00%     0.00%
+MiniMax-M2.7_summary.json                minimax-m2.7                     100.00%    98.99%    97.62%   100.00%   100.00%
+MiniMax-M2.7_summary.json                minimax-m2.7                     100.00%    97.98%    95.24%   100.00%   100.00%
+MiniMax-M2.7_summary.json                minimax-m2.7                     100.00%   100.00%    97.62%   100.00%    50.00%
+====================================================================================================
+
+Averages:
+  1. Query-Success-Rate: 1.0000 (100.00%)
+  2. ToolCalls-Match-Rate: 0.9929 (99.29%)
+  4. ToolCalls-Accuracy: 0.9666 (96.66%)
+  5. Response-Success-Rate-Not-Only-Reasoning: 1.0000 (100.00%)
+  6. Language-Following-Success-Rate: 0.8000 (80.00%)
+
+Results saved to: /Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.7_retry_20260401_200428/metrics_report.json
+[2026-04-01 20:32:09] Results: /Users/minimax/GitHub/MiniMax-Provider-Verifier/output-dir/MiniMax-M2.7_retry_20260401_200428

--- a/output-dir/MiniMax-M2.7/status.json
+++ b/output-dir/MiniMax-M2.7/status.json
@@ -1,0 +1,49 @@
+{
+  "model": "minimax-m2.7",
+  "target": 10,
+  "clean": 10,
+  "total_runs": 10,
+  "failed_loops": [],
+  "clean_loops": [
+    {
+      "loop": "01",
+      "success_count": 101
+    },
+    {
+      "loop": "02",
+      "success_count": 101
+    },
+    {
+      "loop": "03",
+      "success_count": 101
+    },
+    {
+      "loop": "04",
+      "success_count": 101
+    },
+    {
+      "loop": "05",
+      "success_count": 101
+    },
+    {
+      "loop": "06",
+      "success_count": 101
+    },
+    {
+      "loop": "07",
+      "success_count": 101
+    },
+    {
+      "loop": "08",
+      "success_count": 101
+    },
+    {
+      "loop": "09",
+      "success_count": 101
+    },
+    {
+      "loop": "10",
+      "success_count": 101
+    }
+  ]
+}

--- a/validator/tool_calls.py
+++ b/validator/tool_calls.py
@@ -4,6 +4,62 @@ from jsonschema import validate, ValidationError
 
 from validator import BaseValidator
 
+# Common command prefixes that indicate a merged argument when followed by a space
+_COMMON_COMMANDS = [
+    "ls ", "cat ", "git ", "npm ", "npx ", "cd ", "cp ", "mv ", "rm ",
+    "mkdir ", "chmod ", "chown ", "find ", "grep ", "curl ", "wget ",
+    "pip ",
+]
+
+
+def _is_shell_c_invocation(cmd: list) -> bool:
+    """Check if cmd is a shell -c invocation (e.g. bash -lc '...', sh -c '...')."""
+    if not cmd or len(cmd) < 3:
+        return False
+    shell = cmd[0]
+    if shell not in ("bash", "sh", "zsh", "/bin/bash", "/bin/sh", "/bin/zsh",
+                     "/usr/bin/bash", "/usr/bin/sh", "/usr/bin/zsh"):
+        return False
+    # Match patterns: ["bash", "-c", "..."], ["bash", "-lc", "..."],
+    # ["bash", "-l", "-c", "..."], ["bash", "--login", "-c", "..."]
+    for i, arg in enumerate(cmd[1:], start=1):
+        if arg in ("-c", "-lc"):
+            return True
+        if arg in ("-l", "--login"):
+            continue
+        break
+    return False
+
+
+def is_valid_array_command(cmd) -> bool:
+    """Validate that an array command has properly separated arguments.
+
+    Returns False when the model merges multiple arguments into a single
+    string (e.g. ["ls -la /workspace"]) which would fail at execvp() time.
+    Shell -c invocations are exempted because the script string after -c
+    is expected to contain spaces.
+    """
+    if not isinstance(cmd, list) or len(cmd) == 0:
+        return False
+
+    if _is_shell_c_invocation(cmd):
+        return True
+
+    for elem in cmd:
+        if not isinstance(elem, str):
+            return False
+        if " " in elem:
+            # Check if it starts with a common command prefix
+            for prefix in _COMMON_COMMANDS:
+                if elem.startswith(prefix):
+                    return False
+
+    # Single-element array with spaces is suspicious
+    if len(cmd) == 1 and " " in cmd[0]:
+        return False
+
+    return True
+
 
 class ToolCallsValidator(BaseValidator):
     """Validator for tool calls schema validation."""
@@ -140,6 +196,17 @@ class ToolCallsValidator(BaseValidator):
             if isinstance(args, str):
                 args = json.loads(args)
             validate(instance=args, schema=schema)
+
+            # Additional: validate array command format
+            for param_name, param_schema in schema.get("properties", {}).items():
+                if (param_name == "command"
+                        and param_schema.get("type") == "array"
+                        and param_schema.get("items", {}).get("type") == "string"):
+                    cmd_value = args.get(param_name)
+                    if cmd_value is not None and not is_valid_array_command(cmd_value):
+                        print(f"Array command format validation failed for {tool_name}.{param_name}: {cmd_value}")
+                        return False
+
             return True
         except (json.JSONDecodeError, ValidationError) as e:
             print(f"Schema validation failed: {e}")


### PR DESCRIPTION
## Summary
- Add `is_valid_array_command` semantic validation to `ToolCalls-Accuracy` metric to catch merged arguments (e.g. `["ls -la /workspace"]`) that pass JSON Schema but fail at `execvp()` time. Shell `-c` invocations are exempted.
- Update `sample.jsonl` with new test cases
- Add 10-loop baseline results for MiniMax-M2.5 and MiniMax-M2.7 (with new validation applied)

## Metrics (10-loop average)

| Metric | M2.5 | M2.7 |
|--------|------|------|
| Query-Success-Rate | 100.00% | 100.00% |
| ToolCalls-Match-Rate | 99.19% | 99.29% |
| ToolCalls-Accuracy | 96.31% | 96.66% |
| Response-Success-Rate | 100.00% | 100.00% |
| Language-Following | 80.00% | 80.00% |

## Test plan
- [x] Unit tested `is_valid_array_command` with 11 edge cases (all pass)
- [x] Ran 10-loop batch verification for both M2.5 and M2.7 (all loops clean, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)