### PR TITLE
Populate `stream` to `prepare_request` if passed from CLI arg.

### DIFF
--- a/verify.py
+++ b/verify.py
@@ -144,6 +144,8 @@ class ValidatorRunner:
                         message["reasoning_content"] = reason_text
         if self.model:
             req["model"] = self.model
+        if self.stream:
+            req["stream"] = True
         # Remove custom fields, do not pass to API
         req.pop("check_type", None)
         req.pop("expected_tool_call", None)


### PR DESCRIPTION
When `--stream` is passed through CLI, it was actually never populated to the request level so all requests were still sent as non-streaming. This was discovered from running `run_batch_sequential.sh` with `--stream`. 

This PR fixes it.