### PR TITLE
Fix MiniMax-M3 reasoning-token handling in validators

### DIFF
--- a/validator/scenario_check.py
+++ b/validator/scenario_check.py
@@ -34,8 +34,8 @@ class ScenarioCheckValidator(BaseValidator):
 
     @staticmethod
     def _get_visible_content(text: str) -> str:
-        """Strip <think>...</think> blocks to get visible reply only."""
-        return re.sub(r"<think>.*?</think>", "", text, flags=re.DOTALL).strip()
+        """Strip <think>/<mm:think> reasoning blocks to get visible reply only."""
+        return re.sub(r"<(?:mm:)?think>.*?</(?:mm:)?think>", "", text, flags=re.DOTALL).strip()
 
     @staticmethod
     def _extract_actual_order(text: str, expected: list[str]) -> list[str]:


### PR DESCRIPTION
## Summary
MiniMax-M3 wraps its chain-of-thought in a **native `<mm:think>...</mm:think>` token** (both `<think>` and `<mm:think>` are special tokens in the M3 tokenizer), carried inline in the message `content`.

## Fix
Strip both tags:
```python
re.sub(r"<(?:mm:)?think>.*?</(?:mm:)?think>", "", text, flags=re.DOTALL)
```
One-line change in `validator/scenario_check.py`; behavior for `<think>` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)