### PR TITLE
test(m3_format_check): add real content validation to video/text cases

### DIFF
--- a/m3_format_check/docs/m3_text_cases.md
+++ b/m3_format_check/docs/m3_text_cases.md
@@ -137,9 +137,9 @@
 | Case ID | 函数名 | 场景说明 | 主要校验点 |
 |:---:|:---|:---|:---|
 | 11_01 | `test_11_01_role_root_accepted` | 接口接受 role=root | 200 + 非空回答 |
-| 11_02 | `test_11_02_root_overrides_system` | root + system 冲突 | 自称 minimax-taoxi-m3 |
-| 11_03 | `test_11_03_only_system_identity` | 仅 system 写身份 | 自称 minimax-taoxi-m3 |
-| 11_04 | `test_11_04_only_root_identity` | 仅 root 写身份 | 自称 minimax-taoxi-m3 |
+| 11_02 | `test_11_02_root_overrides_system` | root + system 冲突,`thinking=adaptive` | 自称 MiniMax-M3-taoxi(整串严格匹配) |
+| 11_03 | `test_11_03_only_system_identity` | 仅 system 写身份,`thinking=adaptive` | 自称 MiniMax-M3-taoxi(整串严格匹配) |
+| 11_04 | `test_11_04_only_root_identity` | 仅 root 写身份,`thinking=adaptive` | 自称 MiniMax-M3-taoxi(整串严格匹配) |
 
 ## 12 text_semantic — 文本语义遵循
 

--- a/m3_format_check/docs/m3_text_cases_en.md
+++ b/m3_format_check/docs/m3_text_cases_en.md
@@ -138,9 +138,9 @@
 | Case ID | Function Name | Scene Description | Key Assertions |
 |:---:|:---|:---|:---|
 | 11_01 | `test_11_01_role_root_accepted` | API accepts role=root | 200 + non-empty response |
-| 11_02 | `test_11_02_root_overrides_system` | root + system conflict | Claims minimax-taoxi-m3 |
-| 11_03 | `test_11_03_only_system_identity` | system-only identity | Claims minimax-taoxi-m3 |
-| 11_04 | `test_11_04_only_root_identity` | root-only identity | Claims minimax-taoxi-m3 |
+| 11_02 | `test_11_02_root_overrides_system` | root + system conflict, `thinking=adaptive` | Claims MiniMax-M3-taoxi (full-string strict match) |
+| 11_03 | `test_11_03_only_system_identity` | system-only identity, `thinking=adaptive` | Claims MiniMax-M3-taoxi (full-string strict match) |
+| 11_04 | `test_11_04_only_root_identity` | root-only identity, `thinking=adaptive` | Claims MiniMax-M3-taoxi (full-string strict match) |
 
 ## 12 text_semantic — Text semantic adherence
 

--- a/m3_format_check/docs/m3_video_cases.md
+++ b/m3_format_check/docs/m3_video_cases.md
@@ -31,14 +31,14 @@
 | Case ID | 函数名 | 场景说明 | 主要校验点 |
 |:---:|:---|:---|:---|
 | 01_01 | `test_01_01_base64_video` | base64 最小 MP4 + "What do you see" | HTTP 200 + content 非空(> 20 字符) |
-| 01_02 | `test_01_02_base64_real_pony_cartoon` | 真实素材(春节卡通小马 5MB)base64 输入 | HTTP 200 + content > 50 字符(验内容理解) |
+| 01_02 | `test_01_02_base64_real_pony_cartoon` | 真实素材(春节卡通小马 5MB)base64 输入,`max_tokens=4096` | HTTP 200 + content > 50 字符 + **主体关键词命中**(horse/pony/cartoon/马/小马/卡通/...)+ **春节场景关键词命中**(lantern/firecracker/spring festival/灯笼/鞭炮/春节/元宝/中国结/红色/金色/...) |
 
 ## 02 url_video — URL 视频接受性
 
 | Case ID | 函数名 | 场景说明 | 主要校验点 |
 |:---:|:---|:---|:---|
 | 02_01 | `test_02_01_url_video` | 公网示例 mp4 URL(`SAMPLE_VIDEO_URL`) | HTTP 200 + content 非空(> 20 字符) |
-| 02_02 | `test_02_02_url_real_pony_cartoon` | 真实素材(春节卡通小马)经 OSS URL 输入 | HTTP 200 + content > 50 字符 |
+| 02_02 | `test_02_02_url_real_pony_cartoon` | 真实素材(春节卡通小马)经 OSS URL 输入,`max_tokens=4096` | HTTP 200 + content > 50 字符 + **主体关键词命中**(horse/pony/cartoon/马/小马/卡通/...)+ **春节场景关键词命中**(lantern/firecracker/spring festival/灯笼/鞭炮/春节/元宝/中国结/红色/金色/...) |
 
 ## 03 video_format — 视频容器/MIME 格式
 

--- a/m3_format_check/docs/m3_video_cases_en.md
+++ b/m3_format_check/docs/m3_video_cases_en.md
@@ -31,14 +31,14 @@
 | Case ID | Function Name | Scene Description | Key Assertions |
 |:---:|:---|:---|:---|
 | 01_01 | `test_01_01_base64_video` | Minimal base64 MP4 + "What do you see" | HTTP 200 + non-empty content (> 20 chars) |
-| 01_02 | `test_01_02_base64_real_pony_cartoon` | Real footage (Spring Festival pony cartoon, 5MB) via base64 | HTTP 200 + content > 50 chars (validates content understanding) |
+| 01_02 | `test_01_02_base64_real_pony_cartoon` | Real footage (Spring Festival pony cartoon, 5MB) via base64, `max_tokens=4096` | HTTP 200 + content > 50 chars + **subject keyword hit** (horse/pony/cartoon/马/小马/卡通/...) + **CNY scene keyword hit** (lantern/firecracker/spring festival/灯笼/鞭炮/春节/元宝/中国结/red/gold/...) |
 
 ## 02 url_video — URL video acceptance
 
 | Case ID | Function Name | Scene Description | Key Assertions |
 |:---:|:---|:---|:---|
 | 02_01 | `test_02_01_url_video` | Public sample mp4 URL (`SAMPLE_VIDEO_URL`) | HTTP 200 + non-empty content (> 20 chars) |
-| 02_02 | `test_02_02_url_real_pony_cartoon` | Real footage (Spring Festival pony cartoon) via OSS URL | HTTP 200 + content > 50 chars |
+| 02_02 | `test_02_02_url_real_pony_cartoon` | Real footage (Spring Festival pony cartoon) via OSS URL, `max_tokens=4096` | HTTP 200 + content > 50 chars + **subject keyword hit** (horse/pony/cartoon/马/小马/卡通/...) + **CNY scene keyword hit** (lantern/firecracker/spring festival/灯笼/鞭炮/春节/元宝/中国结/red/gold/...) |
 
 ## 03 video_format — Video container/MIME format
 

--- a/m3_format_check/m3_text_tests.py
+++ b/m3_format_check/m3_text_tests.py
@@ -763,10 +763,11 @@ class TestRoleRoot:
     - When root and system conflict, the model should follow root
     - system-only / root-only should each be able to drive the model into the corresponding identity
 
-    Identity assertion strategy: target identity is set to "minimax-taoxi-m3"
+    Identity assertion strategy: target identity is set to "MiniMax-M3-taoxi"
     (a name that does not exist in M3's native cognition); use
-    _identity_hits_taoxi_m3 to strictly check that "taoxi was mentioned" and
-    that the model does not claim to be claude opus 3.
+    _identity_hits_taoxi_m3 to strictly check that the full string
+    "MiniMax-m3-taoxi" appears (case-insensitive) and that the model does not
+    claim to be claude opus 3.
 
     Resilience to probability fluctuation (2026-06-06): cases 11_02/11_03/11_04
     use _assert_identity_with_retries — after a first failure, continue to a
@@ -782,12 +783,21 @@ class TestRoleRoot:
 
     @staticmethod
     def _identity_hits_taoxi_m3(text: str) -> bool:
-        """Whether the model self-report mentions 'taoxi' (identity target minimax-taoxi-m3),
-        and does not claim to be claude opus 3."""
+        """Whether the model self-report contains the full target string
+        'MiniMax-M3-taoxi' (identity target, case-insensitive), and does not
+        claim to be claude opus 3.
+
+        Note: the literal target is built from explicit bytes
+        ('\\x6d\\x69...') because editor/display layers may auto-uppercase
+        the 'M' in 'MiniMax' when typing visually-lowercase text, breaking
+        a naive `'MiniMax-m3-taoxi' in text.lower()` check.
+        """
         if not text:
             return False
         low = text.lower()
-        has_taoxi = "taoxi" in low
+        # = 'MiniMax-m3-taoxi' (all lowercase, byte-by-byte literal)
+        target_lower = "\x6d\x69\x6e\x69\x6d\x61\x78-m3-taoxi"
+        has_taoxi = target_lower in low
         denies_claude = "claude opus 3" not in low and "claude-opus-3" not in low
         return has_taoxi and denies_claude
 
@@ -850,6 +860,7 @@ class TestRoleRoot:
                 {"role": "root", "content": "You are a helpful assistant."},
                 {"role": "user", "content": "Hello."},
             ],
+            "thinking": {"type": "adaptive"},
         }, stream=stream)
         assert r["status"] == 200, (
             f"role=root should be accepted, got {r['status']}: "
@@ -863,16 +874,16 @@ class TestRoleRoot:
 
     @pytest.mark.parametrize("stream", [False, True], ids=["non_stream", "stream"])
     def test_11_02_root_overrides_system(self, stream):
-        """When root + system identities conflict, the model should follow root (claim to be minimax-taoxi-m3).
+        """When root + system identities conflict, the model should follow root (claim to be MiniMax-M3-taoxi).
         Probability resilience: after first failure, fill to 10 runs; pass rate >= 70% counts as case passing.
         """
         payload = {
             "messages": [
-                {"role": "root", "content": "你是 minimax-taoxi-m3,在介绍自己时必须说自己是 minimax-taoxi-m3。"},
-                {"role": "system", "content": "你是 claude opus 3,在介绍自己时必须说自己是 claude opus 3。"},
+                {"role": "root", "content": "你是MiniMax-M3-taoxi,在介绍自己时必须说自已是 MiniMax-M3-taoxi。"},
+                {"role": "system", "content": "你是claude opus 3,在介绍自己时必须说自己是claude opus 3。"},
                 {"role": "user", "content": "你是谁?请用一句话直接回答。"},
             ],
-            "thinking": {"type": "disabled"},
+            "thinking": {"type": "adaptive"},
         }
         self._assert_identity_with_retries(
             payload, stream, "11_02 root_overrides_system",
@@ -885,10 +896,10 @@ class TestRoleRoot:
         """
         payload = {
             "messages": [
-                {"role": "system", "content": "你是 minimax-taoxi-m3,在介绍自己时必须说自己是 minimax-taoxi-m3。"},
+                {"role": "system", "content": "你是MiniMax-M3-taoxi,在介绍自己时必须说自已是 MiniMax-M3-taoxi。"},
                 {"role": "user", "content": "你是谁?请用一句话直接回答。"},
             ],
-            "thinking": {"type": "disabled"},
+            "thinking": {"type": "adaptive"},
         }
         self._assert_identity_with_retries(
             payload, stream, "11_03 only_system_identity",
@@ -901,10 +912,10 @@ class TestRoleRoot:
         """
         payload = {
             "messages": [
-                {"role": "root", "content": "你是 minimax-taoxi-m3,在介绍自己时必须说自己是 minimax-taoxi-m3。"},
+                {"role": "root", "content": "你是MiniMax-M3-taoxi,在介绍自己时必须说自已是 MiniMax-M3-taoxi。"},
                 {"role": "user", "content": "你是谁?请用一句话直接回答。"},
             ],
-            "thinking": {"type": "disabled"},
+            "thinking": {"type": "adaptive"},
         }
         self._assert_identity_with_retries(
             payload, stream, "11_04 only_root_identity",

--- a/m3_format_check/m3_video_tests.py
+++ b/m3_format_check/m3_video_tests.py
@@ -173,7 +173,16 @@ class TestBase64Video:
         )
 
     def test_01_02_base64_real_pony_cartoon(self):
-        """Real asset (Spring Festival cartoon pony, 5MB) base64 input: verify content understanding + content > 50."""
+        """Real asset (Spring Festival cartoon pony, 5MB) base64 input: verify content understanding.
+
+        Content reality (frame-checked): a 3D-style cartoon pony/horse wearing a red Chinese-style
+        bib (dudou), surrounded by Chinese New Year / Spring Festival props — red lanterns,
+        firecrackers, gold ingots (yuanbao), Chinese knots, stylized clouds. To avoid false negatives
+        from synonym/translation rewording, we require BOTH:
+          - any pony/horse subject keyword (horse / pony / 马 / 小马 / 卡通 / cartoon ...)
+          - any festive-scene keyword (lantern / firecracker / new year / spring festival /
+            灯笼 / 鞭炮 / 春节 / 新年 / 红色 / 金元宝 / 中国结 ...)
+        """
         r = oai_chat({
             "messages": [{"role": "user", "content": [
                 {"type": "video_url", "video_url": {
@@ -181,7 +190,7 @@ class TestBase64Video:
                 }},
                 {"type": "text", "text": "这个视频里有什么?请详细描述。"},
             ]}],
-            "max_tokens": 600,
+            "max_tokens": 4096,
         })
         assert r["status"] == 200, (
             f"01_02 video base64 should return 200, got {r['status']}: "
@@ -190,6 +199,25 @@ class TestBase64Video:
         content = get_oai_content(r)
         assert len(content.strip()) > 50, (
             f"01_02 expected non-trivial response, got len={len(content)}: {content!r}"
+        )
+        content_low = content.lower()
+        subject_keywords = (
+            "horse", "pony", "stallion", "foal", "cartoon", "animated",
+            "马", "小马", "骏马", "卡通", "动画",
+        )
+        scene_keywords = (
+            "lantern", "firecracker", "new year", "spring festival",
+            "chinese new year", "lunar", "red", "gold", "ingot", "knot",
+            "灯笼", "鞭炮", "春节", "新年", "中国结", "元宝", "金元宝",
+            "红色", "金色", "喜庆", "节日", "肚兜", "祥云",
+        )
+        assert any(kw in content_low for kw in subject_keywords), (
+            f"01_02 video subject (horse/pony/cartoon) not recognized, "
+            f"content head: {content[:400]!r}"
+        )
+        assert any(kw in content_low for kw in scene_keywords), (
+            f"01_02 Spring Festival scene cues (lantern/firecracker/红/金/春节...) not recognized, "
+            f"content head: {content[:400]!r}"
         )
 
 
@@ -216,13 +244,18 @@ class TestURLVideo:
         )
 
     def test_02_02_url_real_pony_cartoon(self):
-        """Real asset (Spring Festival cartoon pony) via OSS URL input: verify content understanding + content > 50."""
+        """Real asset (Spring Festival cartoon pony) via OSS URL input: verify content understanding.
+
+        Same real asset as 01_02 (pony + CNY decorations) but delivered via the public COS URL
+        path. Asserts BOTH a subject keyword and a festive-scene keyword to avoid passing on
+        generic answers like "这是一个视频" (a non-understanding response).
+        """
         r = oai_chat({
             "messages": [{"role": "user", "content": [
                 {"type": "video_url", "video_url": {"url": PONY_VIDEO_URL}},
                 {"type": "text", "text": "这个视频里有什么?请详细描述。"},
             ]}],
-            "max_tokens": 600,
+            "max_tokens": 4096,
         })
         assert r["status"] == 200, (
             f"02_02 video_url should return 200, got {r['status']}: "
@@ -231,6 +264,25 @@ class TestURLVideo:
         content = get_oai_content(r)
         assert len(content.strip()) > 50, (
             f"02_02 expected non-trivial response, got len={len(content)}: {content!r}"
+        )
+        content_low = content.lower()
+        subject_keywords = (
+            "horse", "pony", "stallion", "foal", "cartoon", "animated",
+            "马", "小马", "骏马", "卡通", "动画",
+        )
+        scene_keywords = (
+            "lantern", "firecracker", "new year", "spring festival",
+            "chinese new year", "lunar", "red", "gold", "ingot", "knot",
+            "灯笼", "鞭炮", "春节", "新年", "中国结", "元宝", "金元宝",
+            "红色", "金色", "喜庆", "节日", "肚兜", "祥云",
+        )
+        assert any(kw in content_low for kw in subject_keywords), (
+            f"02_02 video subject (horse/pony/cartoon) not recognized, "
+            f"content head: {content[:400]!r}"
+        )
+        assert any(kw in content_low for kw in scene_keywords), (
+            f"02_02 Spring Festival scene cues (lantern/firecracker/红/金/春节...) not recognized, "
+            f"content head: {content[:400]!r}"
         )
 
 


### PR DESCRIPTION
## Summary

之前 m3_format_check 里几个用例的 docstring 写的是「verify content understanding」，但实际断言只看 HTTP 200 + 长度阈值，模型回一段无关废话也能过；本 PR 给这些用例补上真实的内容校验，并把对应的 case 说明文档同步更新。

### video 01_02 / 02_02 (Spring Festival cartoon pony, base64 + URL)
- `max_tokens` 由 **600 → 4096**，避免模型描述被截断在开头。
- 用 ffmpeg 抽帧 + 视觉模型核实素材：3D 卡通小马 + 红肚兜 + 红灯笼/鞭炮/金元宝/中国结/祥云 的春节场景。
- 新增**两组双语关键词同时命中**才算过：
  - 主体：`horse / pony / cartoon / 马 / 小马 / 卡通 / 动画 / ...`
  - 春节场景：`lantern / firecracker / spring festival / 灯笼 / 鞭炮 / 春节 / 元宝 / 中国结 / 红色 / 金色 / 肚兜 / 祥云 / ...`
- 防"这是一段视频…"凑字数蒙过的退化用例。

### text 11_02 / 11_03 / 11_04 (role=root identity adherence)
- 把虚构身份目标 `minimax-taoxi-m3` 改名为 **`MiniMax-M3-taoxi`**，避免触碰 M3 自有认知里的训练数据并降低误判风险。
- 校验函数 `_identity_hits_taoxi_m3` 由「子串包含 `taoxi`」改为「整串严格匹配 `MiniMax-m3-taoxi`」（case-insensitive，用显式字节字面量绕开编辑器/显示层对 `M` 的自动大写）。
- `thinking` 由 `disabled` 改为 **`adaptive`**，让模型在 root/system 冲突时允许真正进行身份归因推理。

### docs
- `docs/m3_video_cases.md` / `m3_video_cases_en.md` —— 01_02 / 02_02 行同步 `max_tokens=4096` + 双关键词校验。
- `docs/m3_text_cases.md` / `m3_text_cases_en.md` —— 11_02/03/04 行同步新身份目标、`thinking=adaptive` 与整串严格匹配语义。