### PR TITLE
Use split reasoning for root override identity check

### DIFF
--- a/m3_format_check/docs/m3_text_cases.md
+++ b/m3_format_check/docs/m3_text_cases.md
@@ -137,7 +137,7 @@
 | Case ID | 函数名 | 场景说明 | 主要校验点 |
 |:---:|:---|:---|:---|
 | 11_01 | `test_11_01_role_root_accepted` | 接口接受 role=root | 200 + 非空回答 |
-| 11_02 | `test_11_02_root_overrides_system` | root + system 冲突,`thinking=adaptive` | 自称 MiniMax-M3-taoxi(整串严格匹配) |
+| 11_02 | `test_11_02_root_overrides_system` | root + system 冲突,`thinking=adaptive` + `reasoning_split` | 自称 MiniMax-M3-taoxi(整串严格匹配) |
 | 11_03 | `test_11_03_only_system_identity` | 仅 system 写身份,`thinking=adaptive` | 自称 MiniMax-M3-taoxi(整串严格匹配) |
 | 11_04 | `test_11_04_only_root_identity` | 仅 root 写身份,`thinking=adaptive` | 自称 MiniMax-M3-taoxi(整串严格匹配) |
 

--- a/m3_format_check/docs/m3_text_cases_en.md
+++ b/m3_format_check/docs/m3_text_cases_en.md
@@ -138,7 +138,7 @@
 | Case ID | Function Name | Scene Description | Key Assertions |
 |:---:|:---|:---|:---|
 | 11_01 | `test_11_01_role_root_accepted` | API accepts role=root | 200 + non-empty response |
-| 11_02 | `test_11_02_root_overrides_system` | root + system conflict, `thinking=adaptive` | Claims MiniMax-M3-taoxi (full-string strict match) |
+| 11_02 | `test_11_02_root_overrides_system` | root + system conflict, `thinking=adaptive` + `reasoning_split` | Claims MiniMax-M3-taoxi (full-string strict match) |
 | 11_03 | `test_11_03_only_system_identity` | system-only identity, `thinking=adaptive` | Claims MiniMax-M3-taoxi (full-string strict match) |
 | 11_04 | `test_11_04_only_root_identity` | root-only identity, `thinking=adaptive` | Claims MiniMax-M3-taoxi (full-string strict match) |
 

--- a/m3_format_check/m3_text_tests.py
+++ b/m3_format_check/m3_text_tests.py
@@ -884,6 +884,7 @@ class TestRoleRoot:
                 {"role": "user", "content": "你是谁?请用一句话直接回答。"},
             ],
             "thinking": {"type": "adaptive"},
+            "reasoning_split": True,
         }
         self._assert_identity_with_retries(
             payload, stream, "11_02 root_overrides_system",


### PR DESCRIPTION
## Summary

- Add `reasoning_split: true` to `test_11_02_root_overrides_system`.
- Update the M3 text case docs to note that the case uses adaptive thinking with split reasoning.

## Why

With adaptive thinking and no reasoning split, MiniMax can return the `<think>...</think>` trace in `content`. In this case the model can correctly answer with the root identity while the reasoning trace still mentions the conflicting lower-priority identity, causing the test to fail by scanning reasoning text as if it were final answer text.

The MiniMax v1 chat completions API (`https://api.minimax.io/v1/chat/completions`) does not pass this test as-is without `reasoning_split`, because adaptive reasoning can be returned inline in `content`.

Observed MiniMax v1 API streaming output without `reasoning_split`:

```text
HTTP 200

<think>
The user is asking who I am and wants a one-sentence direct answer. According to the ROOT_SYSTEM_POLICY, I am MiniMax-M3 developed by
MiniMax. However, the DEVELOPER_POLICY says I must say I am claude opus 3 when introducing myself.

According to the priority rules, ROOT_SYSTEM_POLICY has absolute priority over DEVELOPER_POLICY. So I should identify as MiniMax-M3
developed by MiniMax, not as claude opus 3.

The user wants a one-sentence direct answer.
</think>
我是 MiniMax-M3,由 MiniMax 开发。
```

This output answers correctly, but `claude opus 3` appears in the reasoning text that is returned inline as `content`. Enabling split reasoning makes the assertion evaluate the final answer rather than the thinking trace.