### PR TITLE
feat(verify): support extra HTTP headers and dedupe tool_call_id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ toolcall_similarity_results.json
 provider.json
 *.key
 .env
+
+# m3_format_check run logs (contain real API responses / trace ids)
+m3_format_check/logs/

--- a/run_batch_sequential.sh
+++ b/run_batch_sequential.sh
@@ -40,6 +40,7 @@ MAX_WORKERS="10"
 STREAM_MODE=""
 DEBUG_MODE=""
 EXTRA_BODY=""
+EXTRA_HEADERS=""
 DIRECT_URL=""
 DIRECT_MODEL=""
 DIRECT_API_KEY=""
@@ -68,6 +69,14 @@ while [[ $# -gt 0 ]]; do
             ;;
         --extra-body)
             EXTRA_BODY="$2"
+            shift 2
+            ;;
+        --extra-headers)
+            EXTRA_HEADERS="$2"
+            shift 2
+            ;;
+        --loop)
+            LOOP_COUNT="$2"
             shift 2
             ;;
         --url)
@@ -228,7 +237,20 @@ for LOOP_IDX in $(seq 1 $LOOP_COUNT); do
     
     # Generate provider.json
     TEMP_PROVIDER="$MODULE_OUTPUT_DIR/provider.json"
-    cat > "$TEMP_PROVIDER" << EOF
+    if [ -n "$EXTRA_HEADERS" ]; then
+        cat > "$TEMP_PROVIDER" << EOF
+[
+  {
+    "name": "$MODULE",
+    "model": "$DIRECT_MODEL",
+    "base_url": "$PROCESSED_URL",
+    "api_key": "$DIRECT_API_KEY",
+    "default_headers": $EXTRA_HEADERS
+  }
+]
+EOF
+    else
+        cat > "$TEMP_PROVIDER" << EOF
 [
   {
     "name": "$MODULE",
@@ -238,6 +260,7 @@ for LOOP_IDX in $(seq 1 $LOOP_COUNT); do
   }
 ]
 EOF
+    fi
     
     # Copy test data
     TEMP_JSONL="$MODULE_OUTPUT_DIR/test_data.jsonl"

--- a/scripts/batch_verify.py
+++ b/scripts/batch_verify.py
@@ -38,10 +38,14 @@ async def run_provider_verification(
         merged_extra_body = provider_config.get("extra_body", {})
         if extra_body:
             merged_extra_body.update(extra_body)
-        
+
         if merged_extra_body:
             logger.info(f"📦 Using extra_body for provider {provider_name}: {merged_extra_body}")
-        
+
+        default_headers = provider_config.get("default_headers") or {}
+        if default_headers:
+            logger.info(f"📦 Using default_headers for provider {provider_name}: {list(default_headers.keys())}")
+
         runner = ValidatorRunner(
             model=provider_config["model"],
             base_url=provider_config["base_url"],
@@ -57,6 +61,7 @@ async def run_provider_verification(
             debug=debug,
             openrouter_provider=openrouter_provider,
             api_format=api_format,
+            default_headers=default_headers,
         )
         
         await runner.validate_file(file_path)

--- a/verify.py
+++ b/verify.py
@@ -1,9 +1,11 @@
 import argparse
 import asyncio
+import copy
 import hashlib
 import json
 import os
 import time
+from collections import defaultdict, deque
 from datetime import datetime
 from typing import Optional
 
@@ -56,6 +58,7 @@ class ValidatorRunner:
         debug: bool = False,
         openrouter_provider: Optional[str] = None,
         api_format: str = "openai",
+        default_headers: Optional[dict] = None,
     ):
         self.model = model
         self.base_url = base_url
@@ -72,6 +75,7 @@ class ValidatorRunner:
         self.debug = debug
         self.openrouter_provider = openrouter_provider
         self.api_format = api_format
+        self.default_headers = default_headers or {}
         
         # Validators management
         # If no validators specified, use default ToolCallsValidator
@@ -88,7 +92,10 @@ class ValidatorRunner:
             base_url=self.base_url,
             timeout=self.timeout,
             max_retries=self.max_retries,
+            default_headers=self.default_headers or None,
         )
+        if self.default_headers:
+            logger.info(f"Using default_headers: {list(self.default_headers.keys())}")
 
         logger.info(f"Initialized with {len(self.validators)} validators: {[v.name for v in self.validators]}")
         logger.info(f"Results will be saved to {self.output_file}")
@@ -123,7 +130,7 @@ class ValidatorRunner:
     
     def prepare_request(self, request: dict) -> dict:
         """Process request messages and set model."""
-        req = request.copy()
+        req = copy.deepcopy(request)
         if "messages" in req:
             for message in req["messages"]:
                 if message.get("role") == "_input":
@@ -142,6 +149,63 @@ class ValidatorRunner:
                         message["reasoning_content"] = reasoning_text
                     elif reason_text:
                         message["reasoning_content"] = reason_text
+            # Uniquify tool_call_id when the same id appears more than once.
+            # Some providers (e.g. MagikCloud) dedup tool_calls by id on the
+            # server side and then require N tool messages == N unique ids,
+            # which breaks when the dataset reuses `<tool_name>:0` across turns.
+            #
+            # Dataset convention: ids look like `<tool_name>:<n>` (e.g. Bash:0).
+            # Strategy: per `<tool_name>` prefix, track the next free `n`. When
+            # an id is already seen, reassign it to `<tool_name>:<next>` and
+            # propagate the rewrite to the matching tool message (matched by
+            # FIFO of seen-but-unconsumed assistant call ids per `<tool_name>`).
+            def split_id(tid: str) -> tuple[str, int]:
+                # Returns (name, n). Falls back to ("", 0) for unparseable ids.
+                if not isinstance(tid, str):
+                    return ("", 0)
+                if ":" in tid:
+                    name, _, suffix = tid.rpartition(":")
+                    try:
+                        return (name, int(suffix))
+                    except ValueError:
+                        return (tid, 0)
+                return (tid, 0)
+
+            # Per-name next available counter (max-seen + 1).
+            next_n: dict[str, int] = {}
+            # Per-name list of (orig_id -> new_id) rewrites for assistant side.
+            # tool messages consume from this in FIFO order keyed by orig_id.
+            pending: dict[str, dict[str, deque]] = defaultdict(lambda: defaultdict(deque))
+
+            for message in req["messages"]:
+                role = message.get("role")
+                if role == "assistant" and isinstance(message.get("tool_calls"), list):
+                    for tc in message["tool_calls"]:
+                        orig = tc.get("id")
+                        if orig is None:
+                            continue
+                        name, n = split_id(orig)
+                        free = next_n.get(name, 0)
+                        if n >= free:
+                            # First time we see this exact id; keep it as-is.
+                            next_n[name] = n + 1
+                            new_id = orig
+                        else:
+                            # Conflict: reassign to the next free slot.
+                            new_id = f"{name}:{free}"
+                            next_n[name] = free + 1
+                            tc["id"] = new_id
+                        pending[name][orig].append(new_id)
+                elif role == "tool":
+                    orig = message.get("tool_call_id")
+                    if orig is None:
+                        continue
+                    name, _ = split_id(orig)
+                    queue = pending[name].get(orig)
+                    if queue:
+                        new_id = queue.popleft()
+                        if new_id != orig:
+                            message["tool_call_id"] = new_id
         if self.model:
             req["model"] = self.model
         if self.stream:
@@ -554,6 +618,14 @@ async def main():
         ),
     )
     parser.add_argument(
+        "--extra-headers",
+        type=str,
+        help=(
+            "Extra HTTP headers as JSON string, e.g. "
+            '\'{"X-MM-Text-Provider-Model": "gwy-vessl:MiniMaxAI/MiniMax-M2.7"}\''
+        ),
+    )
+    parser.add_argument(
         "--incremental",
         action="store_true",
         help=(
@@ -572,9 +644,17 @@ async def main():
             logger.error(f"Invalid JSON for --extra-body: {e}")
             return
 
+    default_headers = {}
+    if args.extra_headers:
+        try:
+            default_headers = json.loads(args.extra_headers)
+        except json.JSONDecodeError as e:
+            logger.error(f"Invalid JSON for --extra-headers: {e}")
+            return
+
     # Use ToolCallsValidator by default, can add more validators here
     validators = [ToolCallsValidator()]
-    
+
     runner = ValidatorRunner(
         model=args.model,
         base_url=args.base_url,
@@ -587,6 +667,7 @@ async def main():
         extra_body=extra_body,
         incremental=args.incremental,
         validators=validators,
+        default_headers=default_headers,
     )
     await runner.validate_file(args.file_path)
 


### PR DESCRIPTION
## Summary

- Add `--extra-headers` CLI flag (JSON string) to both `verify.py` and `run_batch_sequential.sh`, propagated to the underlying OpenAI client as `default_headers`. Needed for open-platform gateway routing headers such as `X-MM-Text-Provider-Model`.
- `scripts/batch_verify.py` now reads `default_headers` from `provider.json` and forwards it to `ValidatorRunner` (logs key names only, never values).
- Uniquify duplicate `tool_call_id` in `ValidatorRunner.prepare_request`. Some providers (e.g. MagikCloud) dedupe `tool_calls` by id on the server side, which then requires the number of follow-up `tool` messages to equal the number of unique ids. Our datasets reuse ids like `<tool_name>:0` across turns, which previously broke these providers.
- Switch `prepare_request` to `copy.deepcopy` so the rewrite never mutates the input row.
- Ignore `m3_format_check/logs/` (contains real API responses and trace ids).

## Why

These two changes unblock running the verifier against:
- The open-platform gateway (needs custom routing headers per provider).
- MagikCloud-style providers that enforce unique `tool_call_id` per request.

## Details

### `tool_call_id` rewrite strategy

Ids in the dataset follow `<tool_name>:<n>`. Per `<tool_name>` we track `next_n = max_seen + 1`:
- assistant `tool_calls` whose id was already consumed → rewritten to `<tool_name>:<next_n>`.
- The rewrite is queued FIFO per `(name, original_id)` and applied to the matching `role: tool` message's `tool_call_id`.

Unparseable ids fall back to `(id, 0)` and are left alone unless a real collision happens.

### Files

- `verify.py` — new `--extra-headers` arg, `default_headers` plumbed into `ValidatorRunner` and the OpenAI client, `tool_call_id` dedupe in `prepare_request`, `copy.deepcopy` of incoming request.
- `run_batch_sequential.sh` — accept `--extra-headers <json>` and `--loop <N>`; when headers are supplied, emit a `default_headers` field in the generated `provider.json`.
- `scripts/batch_verify.py` — pick up `default_headers` from `provider.json` and forward to `ValidatorRunner`; log key names only.
- `.gitignore` — add `m3_format_check/logs/`.

## Test plan

- [ ] Run verify.py with `--extra-headers '{"X-MM-Text-Provider-Model": "gwy-vessl:MiniMaxAI/MiniMax-M2.7"}'` against the open-platform gateway and confirm the header reaches upstream.
- [ ] Run `run_batch_sequential.sh --extra-headers '<json>' ...` and verify the emitted `provider.json` contains `default_headers`.
- [ ] Replay a multi-turn case that previously reused `Bash:0` across turns against a dedupe-strict provider (MagikCloud) and confirm no `N != N` tool-message error.
- [ ] Sanity-run a normal provider without `--extra-headers` to confirm no regression (no `default_headers` field emitted, request body unchanged).