### PR TITLE
test(m3): assert thinking presence in streaming + tool_call cases

### DIFF
--- a/m3_format_check/m3_image_tests.py
+++ b/m3_format_check/m3_image_tests.py
@@ -546,7 +546,7 @@ class TestImageThinkingCombo:
         r = oai_chat({
             "messages": [{"role": "user", "content": [
                 {"type": "image_url", "image_url": {"url": png_base64()}},
-                {"type": "text", "text": "Describe image and tell weather in Beijing"},
+                {"type": "text", "text": "Describe image and tell weather in Beijing. Think step by step."},
             ]}],
             "tools": [WEATHER_TOOL_OAI],
             "thinking": {"type": "adaptive"},
@@ -559,6 +559,7 @@ class TestImageThinkingCombo:
             schema=WEATHER_TOOL_OAI["function"]["parameters"],
             msg="07_04 image+tool+thinking",
         )
+        assert_thinking_present(r, msg="07_04 image+tool+thinking")
 
 
 # ============================================================

--- a/m3_format_check/m3_text_tests.py
+++ b/m3_format_check/m3_text_tests.py
@@ -1535,7 +1535,7 @@ class TestToolCallCombo:
                 {"id": "c2", "type": "function", "function": {"name": "get_weather", "arguments": '{"location":"Shanghai"}'}}
             ]},
             {"role": "tool", "tool_call_id": "c2", "content": "28°C cloudy"},
-            {"role": "user", "content": "Compare them. Think step by step."},
+            {"role": "user", "content": "Compare them. Think step by step before answering."},
         ]
         r = oai_chat({
             "messages": msgs,

--- a/m3_format_check/m3_text_tests.py
+++ b/m3_format_check/m3_text_tests.py
@@ -219,10 +219,11 @@ class TestThinking:
     def test_04_04_thinking_stream(self):
         """thinking.type=adaptive + stream; verify streaming + thinking coexistence."""
         r = oai_chat({
-            "messages": oai_simple_messages("What is 15*17?"),
+            "messages": oai_simple_messages("What is 15*17? Think step by step."),
             "thinking": {"type": "adaptive"},
         }, stream=True)
         assert_oai_stream_success(r)
+        assert_thinking_present(r, msg="thinking_stream adaptive")
 
 
 # ============================================================
@@ -1438,7 +1439,7 @@ class TestToolCallCombo:
                     {"id": "call_1", "type": "function", "function": {"name": "get_weather", "arguments": '{"location":"Beijing"}'}}
                 ]},
                 {"role": "tool", "tool_call_id": "call_1", "content": "25°C, sunny"},
-                {"role": "user", "content": "And in Shanghai?"},
+                {"role": "user", "content": "And in Shanghai? Think step by step."},
             ],
             "tools": [WEATHER_TOOL_OAI],
             "thinking": {"type": "adaptive"},
@@ -1451,6 +1452,7 @@ class TestToolCallCombo:
             schema=WEATHER_TOOL_OAI["function"]["parameters"],
             msg=f"thinking_tool_call_multiturn stream={stream}",
         )
+        assert_thinking_present(r, msg=f"thinking_tool_call_multiturn stream={stream}")
 
     @pytest.mark.parametrize("stream", [False, True], ids=["non_stream", "stream"])
     def test_15_02_response_format_with_tool_choice(self, stream):
@@ -1533,7 +1535,7 @@ class TestToolCallCombo:
                 {"id": "c2", "type": "function", "function": {"name": "get_weather", "arguments": '{"location":"Shanghai"}'}}
             ]},
             {"role": "tool", "tool_call_id": "c2", "content": "28°C cloudy"},
-            {"role": "user", "content": "Compare them"},
+            {"role": "user", "content": "Compare them. Think step by step."},
         ]
         r = oai_chat({
             "messages": msgs,
@@ -1541,6 +1543,7 @@ class TestToolCallCombo:
             "thinking": {"type": "adaptive"},
         }, stream=stream)
         assert r["status"] == 200
+        assert_thinking_present(r, msg=f"extreme_agent_thinking_fc stream={stream}")
 
     @pytest.mark.parametrize("stream", [False, True], ids=["non_stream", "stream"])
     def test_15_05_system_thinking_tools_combo(self, stream):
@@ -1548,7 +1551,7 @@ class TestToolCallCombo:
         r = oai_chat({
             "messages": [
                 {"role": "system", "content": "You are a weather expert."},
-                {"role": "user", "content": "What's the weather in Tokyo?"},
+                {"role": "user", "content": "What's the weather in Tokyo? Think step by step."},
             ],
             "tools": [WEATHER_TOOL_OAI],
             "thinking": {"type": "adaptive"},
@@ -1561,6 +1564,7 @@ class TestToolCallCombo:
             schema=WEATHER_TOOL_OAI["function"]["parameters"],
             msg=f"system_thinking_tools stream={stream}",
         )
+        assert_thinking_present(r, msg=f"system_thinking_tools stream={stream}")
 
     def test_15_06_tool_roundtrip(self):
         """Full tool call roundtrip: call → result → user follow-up should answer directly (no further tool call)."""


### PR DESCRIPTION
## Summary

- 给 `test_04_04_thinking_stream` / `test_15_01_thinking_tool_call_multiturn` / `test_15_04_extreme_agent_thinking_fc` / `test_15_05_system_thinking_tools_combo` 补 `assert_thinking_present`,之前 4 个 adaptive thinking 用例只校验 HTTP/tool_call,thinking 是否实际触发完全没断
- 4 个用例的末尾 user turn 追加 `"Think step by step."`,引导 adaptive 模式稳定走 think 分支

## Why

用 minimax-m3 官方(`api.minimaxi.com`)复测发现:adaptive + stream + tools 场景下,模型有约 13% 概率直接输出 tool_calls / markdown,完全跳过 `<think>` —— 业务以为"开了 adaptive 就会思考",但实测会偷懒。
加引导词后 5 轮 × 4 用例 = **20/20** 全部触发 `<think>`。

## Test plan

- [x] `M3_BASE_URL=https://api.minimaxi.com M3_MODEL=minimax-m3 pytest m3_format_check/m3_text_tests.py::TestThinking::test_04_04_thinking_stream` × 5 轮 PASS
- [x] `pytest ... TestToolCallCombo::test_15_01_thinking_tool_call_multiturn[stream]` × 5 轮 PASS
- [x] `pytest ... TestToolCallCombo::test_15_04_extreme_agent_thinking_fc[stream]` × 5 轮 PASS
- [x] `pytest ... TestToolCallCombo::test_15_05_system_thinking_tools_combo[stream]` × 5 轮 PASS
- [x] 每轮 dump chunk 验证 content 头部均为 `<think>...`