### PR TITLE
fix(provider-verifier): force-inject max_tokens=40960 for all runs

### DIFF
--- a/scripts/batch_verify.py
+++ b/scripts/batch_verify.py
@@ -295,6 +295,25 @@ async def main():
         except json.JSONDecodeError as e:
             logger.error(f"Invalid JSON for --extra-body: {e}")
             return
+
+    # Force-inject max_tokens=40960 for all M-series Provider verification runs.
+    # Rationale: pass@10 experiments on Together fp4 (batch_20260627_140452/142300 with
+    # default max_tokens=2048) hit `finish_reason=length` on 49/53 failures, which
+    # silently dragged ToolCalls-Match-Rate down from a true ~98% to 93.6%. Re-running
+    # with max_tokens=40960 (batch_20260627_163400) lifted all 7 metrics to pass.
+    # To prevent this footgun from recurring, override unconditionally so every
+    # provider — even when the caller forgot --extra-body or passed a smaller value —
+    # gets a generous output budget. Adjust here if a future model requires more.
+    DEFAULT_MAX_TOKENS = 40960
+    if extra_body is None:
+        extra_body = {}
+    prev_max = extra_body.get("max_tokens")
+    extra_body["max_tokens"] = DEFAULT_MAX_TOKENS
+    if prev_max != DEFAULT_MAX_TOKENS:
+        logger.info(
+            f"🔒 Forced max_tokens={DEFAULT_MAX_TOKENS} "
+            f"(previous={prev_max!r}) to avoid length truncation"
+        )
     
     await batch_verify_providers(
         provider_file=args.provider_file,

--- a/verify.py
+++ b/verify.py
@@ -644,6 +644,18 @@ async def main():
             logger.error(f"Invalid JSON for --extra-body: {e}")
             return
 
+    # Force-inject max_tokens=40960 — see scripts/batch_verify.py for full rationale.
+    # Short version: defaults around 2048 cause `finish_reason=length` truncation that
+    # silently tanks ToolCalls-Match-Rate; this override keeps every run safe.
+    DEFAULT_MAX_TOKENS = 40960
+    prev_max = extra_body.get("max_tokens")
+    extra_body["max_tokens"] = DEFAULT_MAX_TOKENS
+    if prev_max != DEFAULT_MAX_TOKENS:
+        logger.info(
+            f"🔒 Forced max_tokens={DEFAULT_MAX_TOKENS} "
+            f"(previous={prev_max!r}) to avoid length truncation"
+        )
+
     default_headers = {}
     if args.extra_headers:
         try:


### PR DESCRIPTION
Background: pass@10 on Together fp4-gb300 with the default max_tokens (~2048) hit finish_reason=length on 49/53 failures, which silently dragged ToolCalls-Match-Rate from a true ~98% down to 93.6% and Schema-Accuracy from 98.6% to 97.3%. Re-running the same model with max_tokens=40960 restored all seven metrics to passing. To prevent this footgun from recurring across every M-series provider evaluation, unconditionally override max_tokens=40960 in both single-shot (verify.py) and batch (scripts/batch_verify.py) entry points. The previous value, if any, is logged so caller intent stays auditable.